### PR TITLE
App Engine compatible changes.

### DIFF
--- a/certgen.go
+++ b/certgen.go
@@ -77,7 +77,7 @@ func NewTLSCertPair(organization string, validUntil time.Time, extraHosts []stri
 		"localhost": true,
 	}
 
-	addrs, err := net.InterfaceAddrs()
+	addrs, err := interfaceAddrs()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/net.go
+++ b/net.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2013-2014 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// +build !appengine
+
+package btcutil
+
+import (
+	"net"
+)
+
+// interfaceAddrs returns a list of the system's network interface addresses.
+// It is wrapped here so that we can substitute it for other functions when
+// building for systems that do not allow access to net.InterfaceAddrs().
+func interfaceAddrs() ([]net.Addr, error) {
+	return net.InterfaceAddrs()
+}

--- a/net_noop.go
+++ b/net_noop.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2013-2014 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package btcutil
+
+import (
+	"net"
+)
+
+// interfaceAddrs returns a list of the system's network interface addresses.
+// It is wrapped here so that we can substitute it for a no-op function that
+// returns an empty slice of net.Addr when building for systems that do not
+// allow access to net.InterfaceAddrs().
+func interfaceAddrs() ([]net.Addr, error) {
+	return []net.Addr{}, nil
+}


### PR DESCRIPTION
App Engine is unable to use this package as calling [net.InterfaceAddrs()](https://github.com/conformal/btcutil/blob/master/certgen.go#L80) is not allowed at runtime. See [this comment](https://github.com/conformal/fastsha256/pull/1#issuecomment-53837030) for discussion.

This commit factors out net.InterfaceAddrs() into a separate file allowing various implementations to be used. Right now there is a net_noop.go implementation that just returns an empty `[]net.Addr`.

This change makes the `btcutil` package compatible with App Engine.

I am not 100% comfortable with the names of the functions and files so please think of better ones if you can.
