### PR TITLE
Introduce bloom.Builder.

### DIFF
--- a/bloom/builder.go
+++ b/bloom/builder.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2014-2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package bloom
+
+import (
+	"math"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+// Builder represents a bloom filter being built by a client.  The intended use
+// is for a wallet to add data to the filter (using Add, AddOutPoint, and
+// AddShaHash) and create a filterload message to send to a bitcoin full node
+// by calling MsgFilterLoad.
+//
+// Builder methods are not safe for concurrent access.
+type Builder filter
+
+// NewBuilder creates a new bloom filter instance, mainly to be used by SPV
+// clients.  The tweak parameter is a random value added to the seed value.
+// The false positive rate is the probability of a false positive where 1.0 is
+// "match everything" and zero is unachievable.  Thus, providing any false
+// positive rates less than 0 or greater than 1 will be adjusted to the valid
+// range.
+//
+// For more information on what values to use for both elements and fprate,
+// see https://en.wikipedia.org/wiki/Bloom_filter.
+func NewBuilder(elements, tweak uint32, fprate float64, flags wire.BloomUpdateType) *Builder {
+	// Massage the false positive rate to sane values.
+	if fprate > 1.0 {
+		fprate = 1.0
+	}
+	if fprate < 0 {
+		fprate = 1e-9
+	}
+
+	// Calculate the size of the filter in bytes for the given number of
+	// elements and false positive rate.
+	//
+	// Equivalent to m = -(n*ln(p) / ln(2)^2), where m is in bits.
+	// Then clamp it to the maximum filter size and convert to bytes.
+	dataLen := uint32(-1 * float64(elements) * math.Log(fprate) / ln2Squared)
+	dataLen = minUint32(dataLen, wire.MaxFilterLoadFilterSize*8) / 8
+
+	// Calculate the number of hash functions based on the size of the
+	// filter calculated above and the number of elements.
+	//
+	// Equivalent to k = (m/n) * ln(2)
+	// Then clamp it to the maximum allowed hash funcs.
+	hashFuncs := uint32(float64(dataLen*8) / float64(elements) * math.Ln2)
+	hashFuncs = minUint32(hashFuncs, wire.MaxFilterLoadHashFuncs)
+
+	data := make([]byte, dataLen)
+	msg := wire.NewMsgFilterLoad(data, hashFuncs, tweak, flags)
+
+	return (*Builder)(msg)
+}
+
+// Add adds the passed byte slice to the bloom filter.
+func (b *Builder) Add(data []byte) {
+	(*filter)(b).add(data)
+}
+
+// AddOutPoint adds the passed transaction outpoint to the bloom filter.
+func (b *Builder) AddOutPoint(outpoint *wire.OutPoint) {
+	(*filter)(b).addOutPoint(outpoint)
+}
+
+// AddShaHash adds the passed wire.ShaHash to the Filter.
+func (b *Builder) AddShaHash(sha *wire.ShaHash) {
+	(*filter)(b).add(sha.Bytes())
+}
+
+// MsgFilterLoad returns the underlying wire.MsgFilterLoad for the bloom
+// filter.
+func (b *Builder) MsgFilterLoad() *wire.MsgFilterLoad {
+	return (*wire.MsgFilterLoad)(b)
+}

--- a/bloom/example_test.go
+++ b/bloom/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2015 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,17 +15,17 @@ import (
 
 // This example demonstrates how to create a new bloom filter, add a transaction
 // hash to it, and check if the filter matches the transaction.
-func ExampleNewFilter() {
+func ExampleNewBuilder() {
 	rand.Seed(time.Now().UnixNano())
 	tweak := rand.Uint32()
 
 	// Create a new bloom filter intended to hold 10 elements with a 0.01%
 	// false positive rate and does not include any automatic update
 	// functionality when transactions are matched.
-	filter := bloom.NewFilter(10, tweak, 0.0001, wire.BloomUpdateNone)
+	builder := bloom.NewBuilder(10, tweak, 0.0001, wire.BloomUpdateNone)
 
 	// Create a transaction hash and add it to the filter.  This particular
-	// trasaction is the first transaction in block 310,000 of the main
+	// transaction is the first transaction in block 310,000 of the main
 	// bitcoin block chain.
 	txHashStr := "fd611c56ca0d378cdcd16244b45c2ba9588da3adac367c4ef43e808b280b8a45"
 	txHash, err := wire.NewShaHashFromStr(txHashStr)
@@ -33,7 +33,13 @@ func ExampleNewFilter() {
 		fmt.Println(err)
 		return
 	}
-	filter.AddShaHash(txHash)
+	builder.AddShaHash(txHash)
+
+	// Create a message from the bloom filter builder and send to a full node.
+	// The full node then creates a Filter, which can check whether the
+	// transaction matches filter.
+	msg := builder.MsgFilterLoad()
+	filter := bloom.LoadFilter(msg)
 
 	// Show that the filter matches.
 	matches := filter.Matches(txHash.Bytes())

--- a/bloom/filter_test.go
+++ b/bloom/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
+// Copyright (c) 2013-2015 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,12 +14,12 @@ import (
 	"github.com/btcsuite/btcutil/bloom"
 )
 
-// TestFilterLarge ensures a maximum sized filter can be created.
-func TestFilterLarge(t *testing.T) {
-	f := bloom.NewFilter(100000000, 0, 0.01, wire.BloomUpdateNone)
+// TestBuilderLarge ensures a maximum sized filter can be created.
+func TestBuilderLarge(t *testing.T) {
+	f := bloom.NewBuilder(100000000, 0, 0.01, wire.BloomUpdateNone)
 	if len(f.MsgFilterLoad().Filter) > wire.MaxFilterLoadFilterSize {
-		t.Errorf("TestFilterLarge test failed: %d > %d",
-			len(f.MsgFilterLoad().Filter), wire.MaxFilterLoadFilterSize)
+		t.Errorf("%d > %d", len(f.MsgFilterLoad().Filter),
+			wire.MaxFilterLoadFilterSize)
 	}
 }
 
@@ -55,7 +55,7 @@ func TestFilterInsert(t *testing.T) {
 		{"b9300670b4c5366e95b2699e8b18bc75e5f729c5", true},
 	}
 
-	f := bloom.NewFilter(3, 0, 0.01, wire.BloomUpdateAll)
+	builder := bloom.NewBuilder(3, 0, 0.01, wire.BloomUpdateAll)
 
 	for i, test := range tests {
 		data, err := hex.DecodeString(test.hex)
@@ -64,9 +64,10 @@ func TestFilterInsert(t *testing.T) {
 			return
 		}
 		if test.insert {
-			f.Add(data)
+			builder.Add(data)
 		}
 
+		f := bloom.LoadFilter(builder.MsgFilterLoad())
 		result := f.Matches(data)
 		if test.insert != result {
 			t.Errorf("TestFilterInsert Matches test #%d failure: got %v want %v\n",
@@ -82,7 +83,7 @@ func TestFilterInsert(t *testing.T) {
 	}
 
 	got := bytes.NewBuffer(nil)
-	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+	err = builder.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
 	if err != nil {
 		t.Errorf("TestFilterInsert BtcDecode failed: %v\n", err)
 		return
@@ -109,7 +110,7 @@ func TestFilterInsertWithTweak(t *testing.T) {
 		{"b9300670b4c5366e95b2699e8b18bc75e5f729c5", true},
 	}
 
-	f := bloom.NewFilter(3, 2147483649, 0.01, wire.BloomUpdateAll)
+	builder := bloom.NewBuilder(3, 2147483649, 0.01, wire.BloomUpdateAll)
 
 	for i, test := range tests {
 		data, err := hex.DecodeString(test.hex)
@@ -118,9 +119,10 @@ func TestFilterInsertWithTweak(t *testing.T) {
 			return
 		}
 		if test.insert {
-			f.Add(data)
+			builder.Add(data)
 		}
 
+		f := bloom.LoadFilter(builder.MsgFilterLoad())
 		result := f.Matches(data)
 		if test.insert != result {
 			t.Errorf("TestFilterInsertWithTweak Matches test #%d failure: got %v want %v\n",
@@ -135,7 +137,7 @@ func TestFilterInsertWithTweak(t *testing.T) {
 		return
 	}
 	got := bytes.NewBuffer(nil)
-	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+	err = builder.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
 	if err != nil {
 		t.Errorf("TestFilterInsertWithTweak BtcDecode failed: %v\n", err)
 		return
@@ -159,7 +161,7 @@ func TestFilterInsertKey(t *testing.T) {
 		return
 	}
 
-	f := bloom.NewFilter(2, 0, 0.001, wire.BloomUpdateAll)
+	f := bloom.NewBuilder(2, 0, 0.001, wire.BloomUpdateAll)
 	f.Add(wif.SerializePubKey())
 	f.Add(btcutil.Hash160(wif.SerializePubKey()))
 
@@ -238,31 +240,33 @@ func TestFilterBloomMatch(t *testing.T) {
 		return
 	}
 
-	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder := bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr := "b4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"
 	sha, err := wire.NewShaHashFromStr(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
 		return
 	}
-	f.AddShaHash(sha)
+	builder.AddShaHash(sha)
+	f := bloom.LoadFilter(builder.MsgFilterLoad())
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match sha %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "6bff7fcd4f8565ef406dd5d63d4ff94f318fe82027fd4dc451b04474019f74b4"
 	shaBytes, err := hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	builder.Add(shaBytes)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match sha %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "30450220070aca44506c5cef3a16ed519d7c3c39f8aab192c4e1c90d065" +
 		"f37b8a4af6141022100a8e160b856c2d43d27d8fba71e5aef6405b8643" +
 		"ac4cb7cb3c462aced7f14711a01"
@@ -271,12 +275,13 @@ func TestFilterBloomMatch(t *testing.T) {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	builder.Add(shaBytes)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match input signature %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "046d11fee51b0e60666d5049a9101a72741df480b96ee26488a4d3466b95" +
 		"c9a40ac5eeef87e10a5cd336c19a84565f80fa6c547957b7700ff4dfbdefe" +
 		"76036c339"
@@ -285,19 +290,21 @@ func TestFilterBloomMatch(t *testing.T) {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	builder.Add(shaBytes)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match input pubkey %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "04943fdd508053c75000106d3bc6e2754dbcff19"
 	shaBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	builder.Add(shaBytes)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match output address %s", inputStr)
 	}
@@ -305,19 +312,20 @@ func TestFilterBloomMatch(t *testing.T) {
 		t.Errorf("TestFilterBloomMatch spendingTx didn't match output address %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "a266436d2965547608b9e15d9032a7b9d64fa431"
 	shaBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	builder.Add(shaBytes)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match output address %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"
 	sha, err = wire.NewShaHashFromStr(inputStr)
 	if err != nil {
@@ -325,36 +333,39 @@ func TestFilterBloomMatch(t *testing.T) {
 		return
 	}
 	outpoint := wire.NewOutPoint(sha, 0)
-	f.AddOutPoint(outpoint)
+	builder.AddOutPoint(outpoint)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match outpoint %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"
 	sha, err = wire.NewShaHashFromStr(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
 		return
 	}
-	f.AddShaHash(sha)
+	builder.AddShaHash(sha)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched sha %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "0000006d2965547608b9e15d9032a7b9d64fa431"
 	shaBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	builder.Add(shaBytes)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched address %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"
 	sha, err = wire.NewShaHashFromStr(inputStr)
 	if err != nil {
@@ -362,12 +373,13 @@ func TestFilterBloomMatch(t *testing.T) {
 		return
 	}
 	outpoint = wire.NewOutPoint(sha, 1)
-	f.AddOutPoint(outpoint)
+	builder.AddOutPoint(outpoint)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched outpoint %s", inputStr)
 	}
 
-	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder = bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"
 	sha, err = wire.NewShaHashFromStr(inputStr)
 	if err != nil {
@@ -375,14 +387,15 @@ func TestFilterBloomMatch(t *testing.T) {
 		return
 	}
 	outpoint = wire.NewOutPoint(sha, 0)
-	f.AddOutPoint(outpoint)
+	builder.AddOutPoint(outpoint)
+	f = bloom.LoadFilter(builder.MsgFilterLoad())
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched outpoint %s", inputStr)
 	}
 }
 
 func TestFilterInsertUpdateNone(t *testing.T) {
-	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateNone)
+	builder := bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateNone)
 
 	// Add the generation pubkey
 	inputStr := "04eaafc2314def4ca98ac970241bcab022b9c1e1f4ea423a20f134c" +
@@ -393,7 +406,7 @@ func TestFilterInsertUpdateNone(t *testing.T) {
 		t.Errorf("TestFilterInsertUpdateNone DecodeString failed: %v", err)
 		return
 	}
-	f.Add(inputBytes)
+	builder.Add(inputBytes)
 
 	// Add the output address for the 4th transaction
 	inputStr = "b6efd80d99179f4f4ff6f4dd0a007d018c385d21"
@@ -402,7 +415,7 @@ func TestFilterInsertUpdateNone(t *testing.T) {
 		t.Errorf("TestFilterInsertUpdateNone DecodeString failed: %v", err)
 		return
 	}
-	f.Add(inputBytes)
+	builder.Add(inputBytes)
 
 	inputStr = "147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"
 	sha, err := wire.NewShaHashFromStr(inputStr)
@@ -412,6 +425,7 @@ func TestFilterInsertUpdateNone(t *testing.T) {
 	}
 	outpoint := wire.NewOutPoint(sha, 0)
 
+	f := bloom.LoadFilter(builder.MsgFilterLoad())
 	if f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestFilterInsertUpdateNone matched outpoint %s", inputStr)
 		return
@@ -530,7 +544,7 @@ func TestFilterInsertP2PubKeyOnly(t *testing.T) {
 		return
 	}
 
-	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateP2PubkeyOnly)
+	builder := bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateP2PubkeyOnly)
 
 	// Generation pubkey
 	inputStr := "04eaafc2314def4ca98ac970241bcab022b9c1e1f4ea423a20f134c" +
@@ -541,7 +555,7 @@ func TestFilterInsertP2PubKeyOnly(t *testing.T) {
 		t.Errorf("TestFilterInsertP2PubKeyOnly DecodeString failed: %v", err)
 		return
 	}
-	f.Add(inputBytes)
+	builder.Add(inputBytes)
 
 	// Output address of 4th transaction
 	inputStr = "b6efd80d99179f4f4ff6f4dd0a007d018c385d21"
@@ -550,7 +564,9 @@ func TestFilterInsertP2PubKeyOnly(t *testing.T) {
 		t.Errorf("TestFilterInsertP2PubKeyOnly DecodeString failed: %v", err)
 		return
 	}
-	f.Add(inputBytes)
+	builder.Add(inputBytes)
+
+	f := bloom.LoadFilter(builder.MsgFilterLoad())
 
 	// Ignore return value -- this is just used to update the filter.
 	_, _ = bloom.NewMerkleBlock(block, f)
@@ -584,16 +600,22 @@ func TestFilterInsertP2PubKeyOnly(t *testing.T) {
 }
 
 func TestFilterReload(t *testing.T) {
-	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	inputStr := "02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"
+	sha, err := wire.NewShaHashFromStr(inputStr)
+	if err != nil {
+		t.Fatalf("bad sha: %v", err)
+	}
+	builder := bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder.AddShaHash(sha)
 
-	bFilter := bloom.LoadFilter(f.MsgFilterLoad())
-	if bFilter.MsgFilterLoad() == nil {
-		t.Errorf("TestFilterReload LoadFilter test failed")
+	bFilter := bloom.LoadFilter(builder.MsgFilterLoad())
+	if !bFilter.Matches(sha[:]) {
+		t.Errorf("loaded filter did not match sha")
 		return
 	}
-	bFilter.Reload(nil)
 
-	if bFilter.MsgFilterLoad() != nil {
-		t.Errorf("TestFilterReload Reload test failed")
+	bFilter.Reload(nil)
+	if bFilter.Matches(sha[:]) {
+		t.Errorf("unloaded filter matched sha")
 	}
 }

--- a/bloom/merkleblock_test.go
+++ b/bloom/merkleblock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
+// Copyright (c) 2013-2015 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -34,7 +34,7 @@ func TestMerkleBlock3(t *testing.T) {
 		return
 	}
 
-	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+	builder := bloom.NewBuilder(10, 0, 0.000001, wire.BloomUpdateAll)
 
 	inputStr := "63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"
 	sha, err := wire.NewShaHashFromStr(inputStr)
@@ -43,7 +43,8 @@ func TestMerkleBlock3(t *testing.T) {
 		return
 	}
 
-	f.AddShaHash(sha)
+	builder.AddShaHash(sha)
+	f := bloom.LoadFilter(builder.MsgFilterLoad())
 
 	mBlock, _ := bloom.NewMerkleBlock(blk, f)
 


### PR DESCRIPTION
This change separates the old Filter type into two types for a client
(usually a wallet) and a bitcoin server.  These types are Builder and
Filter (for the client and server, respectively).  Builder is used by
a client to create a filterload message to send to a bitcoin full
node.  When this message has been received, the filter can be loaded
(using bloom.FilterLoad) to create the Filter structure.  Data can not
be matched directly against the Builder, and unlike Filter, it is not
safe for concurrent access.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcutil/14)

<!-- Reviewable:end -->
