### PR TITLE
Fix hdkeychain to avoid zeroing net version bytes.

### DIFF
--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -424,7 +424,7 @@ func (k *ExtendedKey) Zero() {
 	zero(k.pubKey)
 	zero(k.chainCode)
 	zero(k.parentFP)
-	zero(k.version)
+	k.version = nil
 	k.key = nil
 	k.depth = 0
 	k.childNum = 0


### PR DESCRIPTION
This commit corrects the Zero function in hdkeychain to nil the version
instead of zeroing the bytes.  This is necessary because the keys are
holding onto a reference into the specific version bytes for the network
as provided by the btcnet package.  Zeroing them causes the bytes in the
btcnet package to be zeroed which then leads to issues later when trying
to use them.

Also, to prevent regressions, new tests have been added to exercise this
scenario.

Pointed out by @jimmysong.
