### PR TITLE
Add testable examples for base58 package.

### DIFF
--- a/base58/README.md
+++ b/base58/README.md
@@ -30,6 +30,21 @@ http://localhost:6060/pkg/github.com/conformal/btcutil/base58
 $ go get github.com/conformal/btcutil/base58
 ```
 
+## Examples
+
+* [Decode Example]
+  (http://godoc.org/github.com/conformal/btcutil/base58#example-Decode)  
+  Demonstrates how to decode modified base58 encoded data.
+* [Encode Example]
+  (http://godoc.org/github.com/conformal/btcutil/base58#example-Encode)  
+  Demonstrates how to encode data using the modified base58 encoding scheme.
+* [CheckDecode Example]
+  (http://godoc.org/github.com/conformal/btcutil/base58#example-CheckDecode)  
+  Demonstrates how to decode Base58Check encoded data.
+* [CheckEncode Example]
+  (http://godoc.org/github.com/conformal/btcutil/base58#example-CheckEncode)  
+  Demonstrates how to encode data using the Base58Check encoding scheme.
+
 ## License
 
 Package base58 is licensed under the [copyfree](http://copyfree.org) ISC

--- a/base58/example_test.go
+++ b/base58/example_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2014 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package base58_test
+
+import (
+	"fmt"
+
+	"github.com/conformal/btcutil/base58"
+)
+
+// This example demonstrates how to decode modified base58 encoded data.
+func ExampleDecode() {
+	// Decode example modified base58 encoded data.
+	encoded := "25JnwSn7XKfNQ"
+	decoded := base58.Decode(encoded)
+
+	// Show the decoded data.
+	fmt.Println("Decoded Data:", string(decoded))
+
+	// Output:
+	// Decoded Data: Test data
+}
+
+// This example demonstrates how to encode data using the modified base58
+// encoding scheme.
+func ExampleEncode() {
+	// Encode example data with the modified base58 encoding scheme.
+	data := []byte("Test data")
+	encoded := base58.Encode(data)
+
+	// Show the encoded data.
+	fmt.Println("Encoded Data:", encoded)
+
+	// Output:
+	// Encoded Data: 25JnwSn7XKfNQ
+}
+
+// This example demonstrates how to decode Base58Check encoded data.
+func ExampleCheckDecode() {
+	// Decode an example Base58Check encoded data.
+	encoded := "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+	decoded, version, err := base58.CheckDecode(encoded)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Show the decoded data.
+	fmt.Printf("Decoded data: %x\n", decoded)
+	fmt.Println("Version Byte:", version)
+
+	// Output:
+	// Decoded data: 62e907b15cbf27d5425399ebf6f0fb50ebb88f18
+	// Version Byte: 0
+}
+
+// This example demonstrates how to encode data using the Base58Check encoding
+// scheme.
+func ExampleCheckEncode() {
+	// Encode example data with the Base58Check encoding scheme.
+	data := []byte("Test data")
+	encoded := base58.CheckEncode(data, 0)
+
+	// Show the encoded data.
+	fmt.Println("Encoded Data:", encoded)
+
+	// Output:
+	// Encoded Data: 182iP79GRURMp7oMHDU
+}


### PR DESCRIPTION
This commit creates and an example test file for the baes58 package that
integrates nicely with Go's example tooling.

This allows the example output to be tested as a part of running the
normal Go tests to help ensure it doesn't get out of date with the code.
