### PR TITLE
Add package documentation for base58 package.

### DIFF
--- a/base58/README.md
+++ b/base58/README.md
@@ -4,8 +4,8 @@ base58
 [![Build Status](https://travis-ci.org/conformal/btcutil.png?branch=master)]
 (https://travis-ci.org/conformal/btcutil)
 
-Package base58 provides an API for for encoding and decoding to and from the
-modified base58 encoding.  It also provides an API to do base58Check encoding,
+Package base58 provides an API for encoding and decoding to and from the
+modified base58 encoding.  It also provides an API to do Base58Check encoding,
 as described [here](https://en.bitcoin.it/wiki/Base58Check_encoding).
 
 A comprehensive suite of tests is provided to ensure proper functionality.

--- a/base58/doc.go
+++ b/base58/doc.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2014 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+/*
+Package base58 provides an API for working with modified base58 and Base58Check
+encodings.
+
+Modified Base58 Encoding
+
+Standard base58 encoding is similar to standard base64 encoding except, as the
+name implies, it uses a 58 character alphabet which results in an alphanumeric
+string and allows some characters which are problematic for humans to be
+excluded.  Due to this, there can be various base58 alphabets.
+
+The modified base58 alphabet used by Bitcoin, and hence this package, omits the
+0, O, I, and l characters that look the same in many fonts and are therefore
+hard to humans to distinguish.
+
+Base58Check Encoding Scheme
+
+The Base58Check encoding scheme is primarily used for Bitcoin addresses at the
+time of this writing, however it can be used to generically encode arbitrary
+byte arrays into human-readable strings along with a version byte that can be
+used to differentiate the same payload.  For Bitcoin addresses, the extra
+version is used to differentiate the network of otherwise identical public keys
+which helps prevent using an address intended for one network on another.
+*/
+package base58


### PR DESCRIPTION
This pull request adds a doc.go file in the base58 package which provides package documentation for godoc.
