### PR TITLE
Remove error return from Block.Sha function.

### DIFF
--- a/block.go
+++ b/block.go
@@ -70,10 +70,10 @@ func (b *Block) Bytes() ([]byte, error) {
 // Sha returns the block identifier hash for the Block.  This is equivalent to
 // calling BlockSha on the underlying wire.MsgBlock, however it caches the
 // result so subsequent calls are more efficient.
-func (b *Block) Sha() (*wire.ShaHash, error) {
+func (b *Block) Sha() *wire.ShaHash {
 	// Return the cached block hash if it has already been generated.
 	if b.blockSha != nil {
-		return b.blockSha, nil
+		return b.blockSha
 	}
 
 	// Generate the block hash.  Ignore the error since BlockSha can't
@@ -82,7 +82,7 @@ func (b *Block) Sha() (*wire.ShaHash, error) {
 
 	// Cache the block hash and return it.
 	b.blockSha = &sha
-	return &sha, nil
+	return &sha
 }
 
 // Tx returns a wrapped transaction (btcutil.Tx) for the transaction at the

--- a/block_test.go
+++ b/block_test.go
@@ -43,11 +43,7 @@ func TestBlock(t *testing.T) {
 
 	// Request the sha multiple times to test generation and caching.
 	for i := 0; i < 2; i++ {
-		sha, err := b.Sha()
-		if err != nil {
-			t.Errorf("Sha: %v", err)
-			continue
-		}
+		sha := b.Sha()
 		if !sha.IsEqual(wantSha) {
 			t.Errorf("Sha #%d mismatched sha - got %v, want %v", i,
 				sha, wantSha)


### PR DESCRIPTION
This pull request remove the error return from the Block.Sha function since it can never fail and ends up causing a lot of unneeded error checking throughout the code base.