### PR TITLE
Use container-based builds on TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: go
 go:
   - 1.3.3
-  - 1.4.1
+  - 1.4.2
+sudo: false
 before_install:
-  - gocleandeps=c16c849abae90c23419d
-  - git clone https://gist.github.com/$gocleandeps.git
-  - goclean=71d0380287747d956a26
-  - git clone https://gist.github.com/$goclean.git
+  - gotools=golang.org/x/tools
+  - if [ "$TRAVIS_GO_VERSION" = "go1.3.3" ]; then gotools=code.google.com/p/go.tools; fi
 install:
   - go get -d -t -v ./...
-  - bash $gocleandeps/gocleandeps.sh
+  - go get -v $gotools/cmd/cover
+  - go get -v $gotools/cmd/vet
+  - go get -v github.com/bradfitz/goimports
+  - go get -v github.com/golang/lint/golint
 script:
   - export PATH=$PATH:$HOME/gopath/bin
-  - bash $goclean/goclean.sh
+  - ./goclean.sh
 after_success:
+  - go get -v github.com/mattn/goveralls
   - goveralls -coverprofile=profile.cov -service=travis-ci

--- a/goclean.sh
+++ b/goclean.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. test coverage (http://blog.golang.org/cover)
+
+set -e
+
+# Automatic checks
+test -z "$(gofmt -l -w .     | tee /dev/stderr)"
+test -z "$(goimports -l -w . | tee /dev/stderr)"
+test -z "$(golint .          | tee /dev/stderr)"
+go vet ./...
+env GORACE="halt_on_error=1" go test -v -race ./...
+
+# Run test coverage on each subdirectories and merge the coverage profile.
+
+echo "mode: count" > profile.cov
+
+# Standard go tooling behavior is to ignore dirs with leading underscores.
+for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -type d);
+do
+if ls $dir/*.go &> /dev/null; then
+  go test -covermode=count -coverprofile=$dir/profile.tmp $dir
+  if [ -f $dir/profile.tmp ]; then
+    cat $dir/profile.tmp | tail -n +2 >> profile.cov
+    rm $dir/profile.tmp
+  fi
+fi
+done
+
+go tool cover -func profile.cov
+
+# To submit the test coverage result to coveralls.io,
+# use goveralls (https://github.com/mattn/goveralls)
+# goveralls -coverprofile=profile.cov -service=travis-ci


### PR DESCRIPTION
Also, import the goclean.sh script directly into this repository and call it directly instead of using a remote gist.