### PR TITLE
Return matched tx indices from NewMerkleBlock.

### DIFF
--- a/bloom/merkleblock.go
+++ b/bloom/merkleblock.go
@@ -77,8 +77,8 @@ func (m *merkleBlock) traverseAndBuild(height, pos uint32) {
 }
 
 // NewMerkleBlock returns a new *wire.MsgMerkleBlock and an array of the matched
-// transaction hashes based on the passed block and filter.
-func NewMerkleBlock(block *btcutil.Block, filter *Filter) (*wire.MsgMerkleBlock, []*wire.ShaHash) {
+// transaction index numbers based on the passed block and filter.
+func NewMerkleBlock(block *btcutil.Block, filter *Filter) (*wire.MsgMerkleBlock, []uint32) {
 	numTx := uint32(len(block.Transactions()))
 	mBlock := merkleBlock{
 		numTx:       numTx,
@@ -87,11 +87,11 @@ func NewMerkleBlock(block *btcutil.Block, filter *Filter) (*wire.MsgMerkleBlock,
 	}
 
 	// Find and keep track of any transactions that match the filter.
-	var matchedHashes []*wire.ShaHash
-	for _, tx := range block.Transactions() {
+	var matchedIndices []uint32
+	for txIndex, tx := range block.Transactions() {
 		if filter.MatchTxAndUpdate(tx) {
 			mBlock.matchedBits = append(mBlock.matchedBits, 0x01)
-			matchedHashes = append(matchedHashes, tx.Sha())
+			matchedIndices = append(matchedIndices, uint32(txIndex))
 		} else {
 			mBlock.matchedBits = append(mBlock.matchedBits, 0x00)
 		}
@@ -120,5 +120,5 @@ func NewMerkleBlock(block *btcutil.Block, filter *Filter) (*wire.MsgMerkleBlock,
 	for i := uint32(0); i < uint32(len(mBlock.bits)); i++ {
 		msgMerkleBlock.Flags[i/8] |= mBlock.bits[i] << (i % 8)
 	}
-	return &msgMerkleBlock, matchedHashes
+	return &msgMerkleBlock, matchedIndices
 }


### PR DESCRIPTION
This pull request modifies the `NewMerkleBlock` function to return the matched transaction indices instead of their hashes.  This is being done because it is much easier for the caller to lookup the matched transactions from the original passed block based on their transaction index within the block versus their hashes.