### PR TITLE
Convert block heights to int32.

### DIFF
--- a/block.go
+++ b/block.go
@@ -19,7 +19,7 @@ type OutOfRangeError string
 // BlockHeightUnknown is the value returned for a block height that is unknown.
 // This is typically because the block has not been inserted into the main chain
 // yet.
-const BlockHeightUnknown = int64(-1)
+const BlockHeightUnknown = int32(-1)
 
 // Error satisfies the error interface and prints human-readable errors.
 func (e OutOfRangeError) Error() string {
@@ -34,7 +34,7 @@ type Block struct {
 	msgBlock        *wire.MsgBlock // Underlying MsgBlock
 	serializedBlock []byte         // Serialized bytes for the block
 	blockSha        *wire.ShaHash  // Cached block hash
-	blockHeight     int64          // Height in the main block chain
+	blockHeight     int32          // Height in the main block chain
 	transactions    []*Tx          // Transactions
 	txnsGenerated   bool           // ALL wrapped transactions generated
 }
@@ -184,12 +184,12 @@ func (b *Block) TxLoc() ([]wire.TxLoc, error) {
 
 // Height returns the saved height of the block in the block chain.  This value
 // will be BlockHeightUnknown if it hasn't already explicitly been set.
-func (b *Block) Height() int64 {
+func (b *Block) Height() int32 {
 	return b.blockHeight
 }
 
 // SetHeight sets the height of the block in the block chain.
-func (b *Block) SetHeight(height int64) {
+func (b *Block) SetHeight(height int32) {
 	b.blockHeight = height
 }
 

--- a/block_test.go
+++ b/block_test.go
@@ -27,7 +27,7 @@ func TestBlock(t *testing.T) {
 	}
 
 	// Ensure block height set and get work properly.
-	wantHeight := int64(100000)
+	wantHeight := int32(100000)
 	b.SetHeight(wantHeight)
 	if gotHeight := b.Height(); gotHeight != wantHeight {
 		t.Errorf("Height: mismatched height - got %v, want %v",


### PR DESCRIPTION
This pull request depends on btcsuite/btcd#481.

This pull request converts all block height references to int32 instead of int64.  The current target block production rate is 10 mins per block which means it will take roughly 40,800 years to reach the maximum
height an int32 affords.  Even if the target rate were lowered to one block per minute, it would still take roughly another 4,080 years to reach the maximum.

In the mean time, there is no reason to use a larger type which results in higher memory usage.