### PR TITLE
docs: Make various README.md files consistent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 btcutil
 =======
 
-[![Build Status](https://travis-ci.org/btcsuite/btcutil.png?branch=master)]
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
 (https://travis-ci.org/btcsuite/btcutil) [![Coverage Status]
-(https://coveralls.io/repos/btcsuite/btcutil/badge.png?branch=master)]
-(https://coveralls.io/r/btcsuite/btcutil?branch=master)
+(http://img.shields.io/coveralls/btcsuite/btcutil.svg)]
+(https://coveralls.io/r/btcsuite/btcutil?branch=master) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcutil)
 
 Package btcutil provides bitcoin-specific convenience functions and types.
 A comprehensive suite of tests is provided to ensure proper functionality.  See
 `test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
 running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.  Package btcutil is licensed under the liberal ISC license.
+report.
 
 This package was developed for btcd, an alternative full-node implementation of
 bitcoin which is under active development by Conformal.  Although it was
@@ -18,23 +21,10 @@ primarily written for btcd, this package has intentionally been designed so it
 can be used as a standalone package for any projects needing the functionality
 provided.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcutil?status.png)]
-(http://godoc.org/github.com/btcsuite/btcutil)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcutil
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcutil
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcutil
+$ go get -u github.com/btcsuite/btcutil
 ```
 
 ## GPG Verification Key

--- a/base58/README.md
+++ b/base58/README.md
@@ -1,33 +1,22 @@
 base58
 ==========
 
-[![Build Status](https://travis-ci.org/btcsuite/btcutil.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcutil)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
+(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcutil/base58?status.png)]
+(http://godoc.org/github.com/btcsuite/btcutil/base58)
 
 Package base58 provides an API for encoding and decoding to and from the
 modified base58 encoding.  It also provides an API to do Base58Check encoding,
 as described [here](https://en.bitcoin.it/wiki/Base58Check_encoding).
 
 A comprehensive suite of tests is provided to ensure proper functionality.
-Package base58 is licensed under the copyfree ISC license.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcutil/base58?status.png)]
-(http://godoc.org/github.com/btcsuite/btcutil/base58)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcutil/base58
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcutil/base58
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcutil/base58
+$ go get -u github.com/btcsuite/btcutil/base58
 ```
 
 ## Examples

--- a/bloom/README.md
+++ b/bloom/README.md
@@ -1,33 +1,23 @@
 bloom
 =====
 
-[![Build Status](https://travis-ci.org/btcsuite/btcutil.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcutil)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
+(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcutil/bloom)
 
 Package bloom provides an API for dealing with bitcoin-specific bloom filters.
 
 A comprehensive suite of tests is provided to ensure proper functionality.  See
 `test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
 running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.  Package coinset is licensed under the liberal ISC license.
+report.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcutil/bloom?status.png)]
-(http://godoc.org/github.com/btcsuite/btcutil/bloom)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcutil/bloom
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcutil/bloom
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcutil/bloom
+$ go get -u github.com/btcsuite/btcutil/bloom
 ```
 
 ## Examples

--- a/coinset/README.md
+++ b/coinset/README.md
@@ -1,8 +1,11 @@
 coinset
 =======
 
-[![Build Status](https://travis-ci.org/btcsuite/btcutil.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcutil)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
+(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcutil/coinset)
 
 Package coinset provides bitcoin-specific convenience functions for selecting
 from and managing sets of unspent transaction outpoints (UTXOs).
@@ -10,25 +13,12 @@ from and managing sets of unspent transaction outpoints (UTXOs).
 A comprehensive suite of tests is provided to ensure proper functionality.  See
 `test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
 running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.  Package coinset is licensed under the liberal ISC license.
+report.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcutil/coinset?status.png)]
-(http://godoc.org/github.com/btcsuite/btcutil/coinset)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcutil/coinset
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcutil/coinset
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcutil/coinset
+$ go get -u github.com/btcsuite/btcutil/coinset
 ```
 
 ## Usage

--- a/hdkeychain/README.md
+++ b/hdkeychain/README.md
@@ -1,8 +1,11 @@
 hdkeychain
 ==========
 
-[![Build Status](https://travis-ci.org/btcsuite/btcutil.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcutil)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
+(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcutil/hdkeychain)
 
 Package hdkeychain provides an API for bitcoin hierarchical deterministic
 extended keys (BIP0032).
@@ -10,7 +13,7 @@ extended keys (BIP0032).
 A comprehensive suite of tests is provided to ensure proper functionality.  See
 `test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
 running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.  Package hdkeychain is licensed under the liberal ISC license.
+report.
 
 ## Feature Overview
 
@@ -35,23 +38,10 @@ report.  Package hdkeychain is licensed under the liberal ISC license.
 - Comprehensive test coverage including the BIP0032 test vectors
 - Benchmarks
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcutil/hdkeychain?status.png)]
-(http://godoc.org/github.com/btcsuite/btcutil/hdkeychain)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcutil/hdkeychain
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcutil/hdkeychain
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcutil/hdkeychain
+$ go get -u github.com/btcsuite/btcutil/hdkeychain
 ```
 
 ## Examples

--- a/txsort/README.md
+++ b/txsort/README.md
@@ -4,6 +4,8 @@ txsort
 [![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
 (https://travis-ci.org/btcsuite/btcutil) [![ISC License]
 (http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcutil/txsort)
 
 Package txsort provides the transaction sorting according to BIPLI01.
 
@@ -18,19 +20,6 @@ sorting on the amount and then on the raw public key script bytes as a tie
 breaker.
 
 A comprehensive suite of tests is provided to ensure proper functionality.
-
-## Documentation
-
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcutil/txsort)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcutil/txsort
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcutil/txsort
 
 ## Installation and Updating
 


### PR DESCRIPTION
First, it removes the documentation section from all the `README.md` files and instead puts a web-based godoc badge and link at the top with the other badges. This is being done since the local `godoc` tool no longer ships with Go by default, so the instructions no longer work without first installing `godoc`. Due to this, pretty much everyone uses the web-based godoc these days anyways. Anyone who has manually installed `godoc` won't need instructions.

Second, it makes sure the ISC license badge is at the top with the other badges and removes the textual reference in the overview section.

Third, it's modifies the Installation section to Installation and Updating and adds a `-u` to the `go get` command since it works for both and thus is simpler.

Finally, it replaces the badges with SVG versions from shields.io so they are consistent.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcutil/63)
<!-- Reviewable:end -->
