### PR TITLE
Fix range check in bloom filter false positive rate

### DIFF
--- a/bloom/filter.go
+++ b/bloom/filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014, 2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -47,7 +47,7 @@ func NewFilter(elements, tweak uint32, fprate float64, flags wire.BloomUpdateTyp
 	if fprate > 1.0 {
 		fprate = 1.0
 	}
-	if fprate < 0 {
+	if fprate < 1e-9 {
 		fprate = 1e-9
 	}
 


### PR DESCRIPTION
Tiny fix here.  If you gave an argument of 0 for the false positive rate in NewFilter(), it would make a 0-length filter, always matching.  That's really a false positive rate of 1 which seems like the opposite effect.  Interpreting a 0 as the lower limit of 1e-9 seems more intuitive behavior when receiving an out-of-bounds argument.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcutil/68)
<!-- Reviewable:end -->
