### PR TITLE
Update TravisCI for Go 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.3.3
-  - 1.4.2
+  - 1.5.3
+  - 1.6
 sudo: false
 before_install:
   - gotools=golang.org/x/tools


### PR DESCRIPTION
Now that Go 1.6 has been released, remove the old Go versions from the configurations tested by TravisCI and add the latest point releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcutil/72)
<!-- Reviewable:end -->
