### PR TITLE
bloom: Correct merkle block test error print.

### DIFF
--- a/bloom/merkleblock_test.go
+++ b/bloom/merkleblock_test.go
@@ -67,7 +67,7 @@ func TestMerkleBlock3(t *testing.T) {
 
 	if !bytes.Equal(want, got.Bytes()) {
 		t.Errorf("TestMerkleBlock3 failed merkle block comparison: "+
-			"got %v want %v", got.Bytes, want)
+			"got %v want %v", got.Bytes(), want)
 		return
 	}
 }


### PR DESCRIPTION
The test would have erroneously printed the function address instead of the received bytes if it failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcutil/73)
<!-- Reviewable:end -->
