### PR TITLE
Add utility functions for blocks and transactions witness data 

### DIFF
--- a/block.go
+++ b/block.go
@@ -32,12 +32,13 @@ func (e OutOfRangeError) Error() string {
 // transactions on their first access so subsequent accesses don't have to
 // repeat the relatively expensive hashing operations.
 type Block struct {
-	msgBlock        *wire.MsgBlock  // Underlying MsgBlock
-	serializedBlock []byte          // Serialized bytes for the block
-	blockHash       *chainhash.Hash // Cached block hash
-	blockHeight     int32           // Height in the main block chain
-	transactions    []*Tx           // Transactions
-	txnsGenerated   bool            // ALL wrapped transactions generated
+	msgBlock                 *wire.MsgBlock  // Underlying MsgBlock
+	serializedBlock          []byte          // Serialized bytes for the block
+	serializedBlockNoWitness []byte          // Serialized bytes for block w/o witness data
+	blockHash                *chainhash.Hash // Cached block hash
+	blockHeight              int32           // Height in the main block chain
+	transactions             []*Tx           // Transactions
+	txnsGenerated            bool            // ALL wrapped transactions generated
 }
 
 // MsgBlock returns the underlying wire.MsgBlock for the Block.
@@ -65,6 +66,27 @@ func (b *Block) Bytes() ([]byte, error) {
 
 	// Cache the serialized bytes and return them.
 	b.serializedBlock = serializedBlock
+	return serializedBlock, nil
+}
+
+// BytesNoWitness returns the serialized bytes for the block with transactions
+// encoded without any witness data.
+func (b *Block) BytesNoWitness() ([]byte, error) {
+	// Return the cached serialized bytes if it has already been generated.
+	if len(b.serializedBlockNoWitness) != 0 {
+		return b.serializedBlockNoWitness, nil
+	}
+
+	// Serialize the MsgBlock.
+	var w bytes.Buffer
+	err := b.msgBlock.SerializeNoWitness(&w)
+	if err != nil {
+		return nil, err
+	}
+	serializedBlock := w.Bytes()
+
+	// Cache the serialized bytes and return them.
+	b.serializedBlockNoWitness = serializedBlock
 	return serializedBlock, nil
 }
 

--- a/tx.go
+++ b/tx.go
@@ -22,9 +22,10 @@ const TxIndexUnknown = -1
 // transaction on its first access so subsequent accesses don't have to repeat
 // the relatively expensive hashing operations.
 type Tx struct {
-	msgTx   *wire.MsgTx     // Underlying MsgTx
-	txHash  *chainhash.Hash // Cached transaction hash
-	txIndex int             // Position within a block or TxIndexUnknown
+	msgTx         *wire.MsgTx     // Underlying MsgTx
+	txHash        *chainhash.Hash // Cached transaction hash
+	txHashWitness *chainhash.Hash // Cached transaction witness hash
+	txIndex       int             // Position within a block or TxIndexUnknown
 }
 
 // MsgTx returns the underlying wire.MsgTx for the transaction.
@@ -45,6 +46,21 @@ func (t *Tx) Hash() *chainhash.Hash {
 	// Cache the hash and return it.
 	hash := t.msgTx.TxHash()
 	t.txHash = &hash
+	return &hash
+}
+
+// WitnessHash returns the witness hash (wtxid) of the transaction.  This is
+// equivalent to calling WitnessHash on the underlying wire.MsgTx, however it
+// caches the result so subsequent calls are more efficient.
+func (t *Tx) WitnessHash() *chainhash.Hash {
+	// Return the cached hash if it has already been generated.
+	if t.txHashWitness != nil {
+		return t.txHashWitness
+	}
+
+	// Cache the hash and return it.
+	hash := t.msgTx.WitnessHash()
+	t.txHashWitness = &hash
 	return &hash
 }
 

--- a/tx.go
+++ b/tx.go
@@ -25,6 +25,7 @@ type Tx struct {
 	msgTx         *wire.MsgTx     // Underlying MsgTx
 	txHash        *chainhash.Hash // Cached transaction hash
 	txHashWitness *chainhash.Hash // Cached transaction witness hash
+	txHasWitness  *bool           // If the transaction has witness data
 	txIndex       int             // Position within a block or TxIndexUnknown
 }
 
@@ -62,6 +63,20 @@ func (t *Tx) WitnessHash() *chainhash.Hash {
 	hash := t.msgTx.WitnessHash()
 	t.txHashWitness = &hash
 	return &hash
+}
+
+// HasWitness returns false if none of the inputs within the transaction
+// contain witness data, true false otherwise. This equivalent to calling
+// HasWitness on the underlying wire.MsgTx, however it caches the result so
+// subsequent calls are more efficient.
+func (t *Tx) HasWitness() bool {
+	if t.txHashWitness != nil {
+		return *t.txHasWitness
+	}
+
+	hasWitness := t.msgTx.HasWitness()
+	t.txHasWitness = &hasWitness
+	return hasWitness
 }
 
 // Index returns the saved index of the transaction within a block.  This value


### PR DESCRIPTION
This PR adds a number of utility messages that will be useful for callers interacting with blocks and transactions that contain witness data: 
- The first new method `btcutil.Block.BytesNoWitness` provides a helper message to generate a serialized version of a block _without_ any witness data (if any). 
- The second new method `btcutil.Tx.WitnessHash` is equivelant to `tx.Hash` but instead returns the `wtxid` of a transaction. 
- The finally added method is `btcutil.Tx.HasWitness`, which is ideneitcal to `tx.HasWitness`, but caches the results. This is a useful performance optimization as a transaction may potentially have thousands of inputs, so we avoid interacting over them repeatedly during block validation and other contexts. 

NOTE: This PR requires btcsuite/btcd#656
