### PR TITLE
bloom: Avoid a few unnecessary hash copies.

### DIFF
--- a/bloom/example_test.go
+++ b/bloom/example_test.go
@@ -36,7 +36,7 @@ func ExampleNewFilter() {
 	filter.AddShaHash(txHash)
 
 	// Show that the filter matches.
-	matches := filter.Matches(txHash.Bytes())
+	matches := filter.Matches(txHash[:])
 	fmt.Println("Filter Matches?:", matches)
 
 	// Output:

--- a/bloom/filter.go
+++ b/bloom/filter.go
@@ -167,7 +167,7 @@ func (bf *Filter) Matches(data []byte) bool {
 func (bf *Filter) matchesOutPoint(outpoint *wire.OutPoint) bool {
 	// Serialize
 	var buf [wire.HashSize + 4]byte
-	copy(buf[:], outpoint.Hash.Bytes())
+	copy(buf[:], outpoint.Hash[:])
 	binary.LittleEndian.PutUint32(buf[wire.HashSize:], outpoint.Index)
 
 	return bf.matches(buf[:])
@@ -217,9 +217,9 @@ func (bf *Filter) Add(data []byte) {
 // AddShaHash adds the passed wire.ShaHash to the Filter.
 //
 // This function is safe for concurrent access.
-func (bf *Filter) AddShaHash(sha *wire.ShaHash) {
+func (bf *Filter) AddShaHash(hash *wire.ShaHash) {
 	bf.mtx.Lock()
-	bf.add(sha.Bytes())
+	bf.add(hash[:])
 	bf.mtx.Unlock()
 }
 
@@ -229,7 +229,7 @@ func (bf *Filter) AddShaHash(sha *wire.ShaHash) {
 func (bf *Filter) addOutPoint(outpoint *wire.OutPoint) {
 	// Serialize
 	var buf [wire.HashSize + 4]byte
-	copy(buf[:], outpoint.Hash.Bytes())
+	copy(buf[:], outpoint.Hash[:])
 	binary.LittleEndian.PutUint32(buf[wire.HashSize:], outpoint.Index)
 
 	bf.add(buf[:])
@@ -272,7 +272,7 @@ func (bf *Filter) maybeAddOutpoint(pkScript []byte, outHash *wire.ShaHash, outId
 func (bf *Filter) matchTxAndUpdate(tx *btcutil.Tx) bool {
 	// Check if the filter matches the hash of the transaction.
 	// This is useful for finding transactions when they appear in a block.
-	matched := bf.matches(tx.Sha().Bytes())
+	matched := bf.matches(tx.Sha()[:])
 
 	// Check if the filter matches any data elements in the public key
 	// scripts of any of the outputs.  When it does, add the outpoint that


### PR DESCRIPTION
This changes several places which call the Bytes method of a ShaHash to
simply use a slice of it in order to avoid the extra unnecessary copies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcutil/76)
<!-- Reviewable:end -->
