### PR TITLE
Update for recent chainhash-related API changes.

### DIFF
--- a/block.go
+++ b/block.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -31,12 +32,12 @@ func (e OutOfRangeError) Error() string {
 // transactions on their first access so subsequent accesses don't have to
 // repeat the relatively expensive hashing operations.
 type Block struct {
-	msgBlock        *wire.MsgBlock // Underlying MsgBlock
-	serializedBlock []byte         // Serialized bytes for the block
-	blockSha        *wire.ShaHash  // Cached block hash
-	blockHeight     int32          // Height in the main block chain
-	transactions    []*Tx          // Transactions
-	txnsGenerated   bool           // ALL wrapped transactions generated
+	msgBlock        *wire.MsgBlock  // Underlying MsgBlock
+	serializedBlock []byte          // Serialized bytes for the block
+	blockHash       *chainhash.Hash // Cached block hash
+	blockHeight     int32           // Height in the main block chain
+	transactions    []*Tx           // Transactions
+	txnsGenerated   bool            // ALL wrapped transactions generated
 }
 
 // MsgBlock returns the underlying wire.MsgBlock for the Block.
@@ -67,19 +68,19 @@ func (b *Block) Bytes() ([]byte, error) {
 	return serializedBlock, nil
 }
 
-// Sha returns the block identifier hash for the Block.  This is equivalent to
-// calling BlockSha on the underlying wire.MsgBlock, however it caches the
+// Hash returns the block identifier hash for the Block.  This is equivalent to
+// calling BlockHash on the underlying wire.MsgBlock, however it caches the
 // result so subsequent calls are more efficient.
-func (b *Block) Sha() *wire.ShaHash {
+func (b *Block) Hash() *chainhash.Hash {
 	// Return the cached block hash if it has already been generated.
-	if b.blockSha != nil {
-		return b.blockSha
+	if b.blockHash != nil {
+		return b.blockHash
 	}
 
 	// Cache the block hash and return it.
-	sha := b.msgBlock.BlockSha()
-	b.blockSha = &sha
-	return &sha
+	hash := b.msgBlock.BlockHash()
+	b.blockHash = &hash
+	return &hash
 }
 
 // Tx returns a wrapped transaction (btcutil.Tx) for the transaction at the
@@ -145,12 +146,12 @@ func (b *Block) Transactions() []*Tx {
 	return b.transactions
 }
 
-// TxSha returns the hash for the requested transaction number in the Block.
+// TxHash returns the hash for the requested transaction number in the Block.
 // The supplied index is 0 based.  That is to say, the first transaction in the
-// block is txNum 0.  This is equivalent to calling TxSha on the underlying
+// block is txNum 0.  This is equivalent to calling TxHash on the underlying
 // wire.MsgTx, however it caches the result so subsequent calls are more
 // efficient.
-func (b *Block) TxSha(txNum int) (*wire.ShaHash, error) {
+func (b *Block) TxHash(txNum int) (*chainhash.Hash, error) {
 	// Attempt to get a wrapped transaction for the specified index.  It
 	// will be created lazily if needed or simply return the cached version
 	// if it has already been generated.
@@ -161,7 +162,7 @@ func (b *Block) TxSha(txNum int) (*wire.ShaHash, error) {
 
 	// Defer to the wrapped transaction which will return the cached hash if
 	// it has already been generated.
-	return tx.Sha(), nil
+	return tx.Hash(), nil
 }
 
 // TxLoc returns the offsets and lengths of each transaction in a raw block.

--- a/block_test.go
+++ b/block_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
@@ -35,23 +36,23 @@ func TestBlock(t *testing.T) {
 	}
 
 	// Hash for block 100,000.
-	wantShaStr := "3ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506"
-	wantSha, err := wire.NewShaHashFromStr(wantShaStr)
+	wantHashStr := "3ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506"
+	wantHash, err := chainhash.NewHashFromStr(wantHashStr)
 	if err != nil {
-		t.Errorf("NewShaHashFromStr: %v", err)
+		t.Errorf("NewHashFromStr: %v", err)
 	}
 
-	// Request the sha multiple times to test generation and caching.
+	// Request the hash multiple times to test generation and caching.
 	for i := 0; i < 2; i++ {
-		sha := b.Sha()
-		if !sha.IsEqual(wantSha) {
-			t.Errorf("Sha #%d mismatched sha - got %v, want %v", i,
-				sha, wantSha)
+		hash := b.Hash()
+		if !hash.IsEqual(wantHash) {
+			t.Errorf("Hash #%d mismatched hash - got %v, want %v",
+				i, hash, wantHash)
 		}
 	}
 
-	// Shas for the transactions in Block100000.
-	wantTxShas := []string{
+	// Hashes for the transactions in Block100000.
+	wantTxHashes := []string{
 		"8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87",
 		"fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4",
 		"6359f0868171b1d194cbee1af2f16ea598ae8fad666d9b012c8ed2b79a236ec4",
@@ -61,14 +62,15 @@ func TestBlock(t *testing.T) {
 	// Create a new block to nuke all cached data.
 	b = btcutil.NewBlock(&Block100000)
 
-	// Request sha for all transactions one at a time via Tx.
-	for i, txSha := range wantTxShas {
-		wantSha, err := wire.NewShaHashFromStr(txSha)
+	// Request hash for all transactions one at a time via Tx.
+	for i, txHash := range wantTxHashes {
+		wantHash, err := chainhash.NewHashFromStr(txHash)
 		if err != nil {
-			t.Errorf("NewShaHashFromStr: %v", err)
+			t.Errorf("NewHashFromStr: %v", err)
 		}
 
-		// Request the sha multiple times to test generation and caching.
+		// Request the hash multiple times to test generation and
+		// caching.
 		for j := 0; j < 2; j++ {
 			tx, err := b.Tx(i)
 			if err != nil {
@@ -76,10 +78,10 @@ func TestBlock(t *testing.T) {
 				continue
 			}
 
-			sha := tx.Sha()
-			if !sha.IsEqual(wantSha) {
-				t.Errorf("Sha #%d mismatched sha - got %v, "+
-					"want %v", j, sha, wantSha)
+			hash := tx.Hash()
+			if !hash.IsEqual(wantHash) {
+				t.Errorf("Hash #%d mismatched hash - got %v, "+
+					"want %v", j, hash, wantHash)
 				continue
 			}
 		}
@@ -94,24 +96,24 @@ func TestBlock(t *testing.T) {
 		transactions := b.Transactions()
 
 		// Ensure we get the expected number of transactions.
-		if len(transactions) != len(wantTxShas) {
+		if len(transactions) != len(wantTxHashes) {
 			t.Errorf("Transactions #%d mismatched number of "+
 				"transactions - got %d, want %d", i,
-				len(transactions), len(wantTxShas))
+				len(transactions), len(wantTxHashes))
 			continue
 		}
 
-		// Ensure all of the shas match.
+		// Ensure all of the hashes match.
 		for j, tx := range transactions {
-			wantSha, err := wire.NewShaHashFromStr(wantTxShas[j])
+			wantHash, err := chainhash.NewHashFromStr(wantTxHashes[j])
 			if err != nil {
-				t.Errorf("NewShaHashFromStr: %v", err)
+				t.Errorf("NewHashFromStr: %v", err)
 			}
 
-			sha := tx.Sha()
-			if !sha.IsEqual(wantSha) {
-				t.Errorf("Transactions #%d mismatched shas - "+
-					"got %v, want %v", j, sha, wantSha)
+			hash := tx.Hash()
+			if !hash.IsEqual(wantHash) {
+				t.Errorf("Transactions #%d mismatched hashes "+
+					"- got %v, want %v", j, hash, wantHash)
 				continue
 			}
 		}
@@ -262,15 +264,15 @@ func TestBlockErrors(t *testing.T) {
 			"got %v, want %v", err, io.EOF)
 	}
 
-	// Ensure TxSha returns expected error on invalid indices.
-	_, err = b.TxSha(-1)
+	// Ensure TxHash returns expected error on invalid indices.
+	_, err = b.TxHash(-1)
 	if _, ok := err.(btcutil.OutOfRangeError); !ok {
-		t.Errorf("TxSha: wrong error - got: %v <%T>, "+
+		t.Errorf("TxHash: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, btcutil.OutOfRangeError(""))
 	}
-	_, err = b.TxSha(len(Block100000.Transactions) + 1)
+	_, err = b.TxHash(len(Block100000.Transactions) + 1)
 	if _, ok := err.(btcutil.OutOfRangeError); !ok {
-		t.Errorf("TxSha: wrong error - got: %v <%T>, "+
+		t.Errorf("TxHash: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, btcutil.OutOfRangeError(""))
 	}
 
@@ -302,13 +304,13 @@ func TestBlockErrors(t *testing.T) {
 var Block100000 = wire.MsgBlock{
 	Header: wire.BlockHeader{
 		Version: 1,
-		PrevBlock: wire.ShaHash([32]byte{ // Make go vet happy.
+		PrevBlock: chainhash.Hash([32]byte{ // Make go vet happy.
 			0x50, 0x12, 0x01, 0x19, 0x17, 0x2a, 0x61, 0x04,
 			0x21, 0xa6, 0xc3, 0x01, 0x1d, 0xd3, 0x30, 0xd9,
 			0xdf, 0x07, 0xb6, 0x36, 0x16, 0xc2, 0xcc, 0x1f,
 			0x1c, 0xd0, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
 		}), // 000000000002d01c1fccc21636b607dfd930d31d01c3a62104612a1719011250
-		MerkleRoot: wire.ShaHash([32]byte{ // Make go vet happy.
+		MerkleRoot: chainhash.Hash([32]byte{ // Make go vet happy.
 			0x66, 0x57, 0xa9, 0x25, 0x2a, 0xac, 0xd5, 0xc0,
 			0xb2, 0x94, 0x09, 0x96, 0xec, 0xff, 0x95, 0x22,
 			0x28, 0xc3, 0x06, 0x7c, 0xc3, 0x8d, 0x48, 0x85,
@@ -324,7 +326,7 @@ var Block100000 = wire.MsgBlock{
 			TxIn: []*wire.TxIn{
 				{
 					PreviousOutPoint: wire.OutPoint{
-						Hash:  wire.ShaHash{},
+						Hash:  chainhash.Hash{},
 						Index: 0xffffffff,
 					},
 					SignatureScript: []byte{
@@ -358,7 +360,7 @@ var Block100000 = wire.MsgBlock{
 			TxIn: []*wire.TxIn{
 				{
 					PreviousOutPoint: wire.OutPoint{
-						Hash: wire.ShaHash([32]byte{ // Make go vet happy.
+						Hash: chainhash.Hash([32]byte{ // Make go vet happy.
 							0x03, 0x2e, 0x38, 0xe9, 0xc0, 0xa8, 0x4c, 0x60,
 							0x46, 0xd6, 0x87, 0xd1, 0x05, 0x56, 0xdc, 0xac,
 							0xc4, 0x1d, 0x27, 0x5e, 0xc5, 0x5f, 0xc0, 0x07,
@@ -427,7 +429,7 @@ var Block100000 = wire.MsgBlock{
 			TxIn: []*wire.TxIn{
 				{
 					PreviousOutPoint: wire.OutPoint{
-						Hash: wire.ShaHash([32]byte{ // Make go vet happy.
+						Hash: chainhash.Hash([32]byte{ // Make go vet happy.
 							0xc3, 0x3e, 0xbf, 0xf2, 0xa7, 0x09, 0xf1, 0x3d,
 							0x9f, 0x9a, 0x75, 0x69, 0xab, 0x16, 0xa3, 0x27,
 							0x86, 0xaf, 0x7d, 0x7e, 0x2d, 0xe0, 0x92, 0x65,
@@ -495,7 +497,7 @@ var Block100000 = wire.MsgBlock{
 			TxIn: []*wire.TxIn{
 				{
 					PreviousOutPoint: wire.OutPoint{
-						Hash: wire.ShaHash([32]byte{ // Make go vet happy.
+						Hash: chainhash.Hash([32]byte{ // Make go vet happy.
 							0x0b, 0x60, 0x72, 0xb3, 0x86, 0xd4, 0xa7, 0x73,
 							0x23, 0x52, 0x37, 0xf6, 0x4c, 0x11, 0x26, 0xac,
 							0x3b, 0x24, 0x0c, 0x84, 0xb9, 0x17, 0xa3, 0x90,

--- a/bloom/example_test.go
+++ b/bloom/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil/bloom"
 )
@@ -28,12 +29,12 @@ func ExampleNewFilter() {
 	// trasaction is the first transaction in block 310,000 of the main
 	// bitcoin block chain.
 	txHashStr := "fd611c56ca0d378cdcd16244b45c2ba9588da3adac367c4ef43e808b280b8a45"
-	txHash, err := wire.NewShaHashFromStr(txHashStr)
+	txHash, err := chainhash.NewHashFromStr(txHashStr)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	filter.AddShaHash(txHash)
+	filter.AddHash(txHash)
 
 	// Show that the filter matches.
 	matches := filter.Matches(txHash[:])

--- a/bloom/filter_test.go
+++ b/bloom/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, 2014, 2016 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/bloom"
@@ -126,9 +127,9 @@ func TestFilterFPRange(t *testing.T) {
 
 	for _, test := range tests {
 		// Convert test input to appropriate types.
-		hash, err := wire.NewShaHashFromStr(test.hash)
+		hash, err := chainhash.NewHashFromStr(test.hash)
 		if err != nil {
-			t.Errorf("NewShaHashFromStr unexpected error: %v", err)
+			t.Errorf("NewHashFromStr unexpected error: %v", err)
 			continue
 		}
 		want, err := hex.DecodeString(test.want)
@@ -140,7 +141,7 @@ func TestFilterFPRange(t *testing.T) {
 		// Add the test hash to the bloom filter and ensure the
 		// filter serializes to the expected bytes.
 		f := test.filter
-		f.AddShaHash(hash)
+		f.AddHash(hash)
 		got := bytes.NewBuffer(nil)
 		err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
 		if err != nil {
@@ -300,38 +301,38 @@ func TestFilterBloomMatch(t *testing.T) {
 
 	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr := "b4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"
-	sha, err := wire.NewShaHashFromStr(inputStr)
+	hash, err := chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	f.AddShaHash(sha)
+	f.AddHash(hash)
 	if !f.MatchTxAndUpdate(tx) {
-		t.Errorf("TestFilterBloomMatch didn't match sha %s", inputStr)
+		t.Errorf("TestFilterBloomMatch didn't match hash %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "6bff7fcd4f8565ef406dd5d63d4ff94f318fe82027fd4dc451b04474019f74b4"
-	shaBytes, err := hex.DecodeString(inputStr)
+	hashBytes, err := hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
-		t.Errorf("TestFilterBloomMatch didn't match sha %s", inputStr)
+		t.Errorf("TestFilterBloomMatch didn't match hash %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "30450220070aca44506c5cef3a16ed519d7c3c39f8aab192c4e1c90d065" +
 		"f37b8a4af6141022100a8e160b856c2d43d27d8fba71e5aef6405b8643" +
 		"ac4cb7cb3c462aced7f14711a01"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match input signature %s", inputStr)
 	}
@@ -340,24 +341,24 @@ func TestFilterBloomMatch(t *testing.T) {
 	inputStr = "046d11fee51b0e60666d5049a9101a72741df480b96ee26488a4d3466b95" +
 		"c9a40ac5eeef87e10a5cd336c19a84565f80fa6c547957b7700ff4dfbdefe" +
 		"76036c339"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match input pubkey %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "04943fdd508053c75000106d3bc6e2754dbcff19"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match output address %s", inputStr)
 	}
@@ -367,24 +368,24 @@ func TestFilterBloomMatch(t *testing.T) {
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "a266436d2965547608b9e15d9032a7b9d64fa431"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match output address %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"
-	sha, err = wire.NewShaHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	outpoint := wire.NewOutPoint(sha, 0)
+	outpoint := wire.NewOutPoint(hash, 0)
 	f.AddOutPoint(outpoint)
 	if !f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch didn't match outpoint %s", inputStr)
@@ -392,36 +393,36 @@ func TestFilterBloomMatch(t *testing.T) {
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"
-	sha, err = wire.NewShaHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	f.AddShaHash(sha)
+	f.AddHash(hash)
 	if f.MatchTxAndUpdate(tx) {
-		t.Errorf("TestFilterBloomMatch matched sha %s", inputStr)
+		t.Errorf("TestFilterBloomMatch matched hash %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "0000006d2965547608b9e15d9032a7b9d64fa431"
-	shaBytes, err = hex.DecodeString(inputStr)
+	hashBytes, err = hex.DecodeString(inputStr)
 	if err != nil {
 		t.Errorf("TestFilterBloomMatch DecodeString failed: %v\n", err)
 		return
 	}
-	f.Add(shaBytes)
+	f.Add(hashBytes)
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched address %s", inputStr)
 	}
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"
-	sha, err = wire.NewShaHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	outpoint = wire.NewOutPoint(sha, 1)
+	outpoint = wire.NewOutPoint(hash, 1)
 	f.AddOutPoint(outpoint)
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched outpoint %s", inputStr)
@@ -429,12 +430,12 @@ func TestFilterBloomMatch(t *testing.T) {
 
 	f = bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 	inputStr = "000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"
-	sha, err = wire.NewShaHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterBloomMatch NewShaHashFromStr failed: %v\n", err)
+		t.Errorf("TestFilterBloomMatch NewHashFromStr failed: %v\n", err)
 		return
 	}
-	outpoint = wire.NewOutPoint(sha, 0)
+	outpoint = wire.NewOutPoint(hash, 0)
 	f.AddOutPoint(outpoint)
 	if f.MatchTxAndUpdate(tx) {
 		t.Errorf("TestFilterBloomMatch matched outpoint %s", inputStr)
@@ -465,12 +466,12 @@ func TestFilterInsertUpdateNone(t *testing.T) {
 	f.Add(inputBytes)
 
 	inputStr = "147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"
-	sha, err := wire.NewShaHashFromStr(inputStr)
+	hash, err := chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterInsertUpdateNone NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestFilterInsertUpdateNone NewHashFromStr failed: %v", err)
 		return
 	}
-	outpoint := wire.NewOutPoint(sha, 0)
+	outpoint := wire.NewOutPoint(hash, 0)
 
 	if f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestFilterInsertUpdateNone matched outpoint %s", inputStr)
@@ -478,12 +479,12 @@ func TestFilterInsertUpdateNone(t *testing.T) {
 	}
 
 	inputStr = "02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"
-	sha, err = wire.NewShaHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestFilterInsertUpdateNone NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestFilterInsertUpdateNone NewHashFromStr failed: %v", err)
 		return
 	}
-	outpoint = wire.NewOutPoint(sha, 0)
+	outpoint = wire.NewOutPoint(hash, 0)
 
 	if f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestFilterInsertUpdateNone matched outpoint %s", inputStr)
@@ -617,12 +618,12 @@ func TestFilterInsertP2PubKeyOnly(t *testing.T) {
 
 	// We should match the generation pubkey
 	inputStr = "147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"
-	sha, err := wire.NewShaHashFromStr(inputStr)
+	hash, err := chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestMerkleBlockP2PubKeyOnly NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestMerkleBlockP2PubKeyOnly NewHashFromStr failed: %v", err)
 		return
 	}
-	outpoint := wire.NewOutPoint(sha, 0)
+	outpoint := wire.NewOutPoint(hash, 0)
 	if !f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestMerkleBlockP2PubKeyOnly didn't match the generation "+
 			"outpoint %s", inputStr)
@@ -631,12 +632,12 @@ func TestFilterInsertP2PubKeyOnly(t *testing.T) {
 
 	// We should not match the 4th transaction, which is not p2pk
 	inputStr = "02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"
-	sha, err = wire.NewShaHashFromStr(inputStr)
+	hash, err = chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestMerkleBlockP2PubKeyOnly NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestMerkleBlockP2PubKeyOnly NewHashFromStr failed: %v", err)
 		return
 	}
-	outpoint = wire.NewOutPoint(sha, 0)
+	outpoint = wire.NewOutPoint(hash, 0)
 	if f.MatchesOutPoint(outpoint) {
 		t.Errorf("TestMerkleBlockP2PubKeyOnly matched outpoint %s", inputStr)
 		return

--- a/bloom/merkleblock.go
+++ b/bloom/merkleblock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -6,6 +6,7 @@ package bloom
 
 import (
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
@@ -14,8 +15,8 @@ import (
 // wire.MsgMerkleBlock according to a filter.
 type merkleBlock struct {
 	numTx       uint32
-	allHashes   []*wire.ShaHash
-	finalHashes []*wire.ShaHash
+	allHashes   []*chainhash.Hash
+	finalHashes []*chainhash.Hash
 	matchedBits []byte
 	bits        []byte
 }
@@ -28,12 +29,12 @@ func (m *merkleBlock) calcTreeWidth(height uint32) uint32 {
 
 // calcHash returns the hash for a sub-tree given a depth-first height and
 // node position.
-func (m *merkleBlock) calcHash(height, pos uint32) *wire.ShaHash {
+func (m *merkleBlock) calcHash(height, pos uint32) *chainhash.Hash {
 	if height == 0 {
 		return m.allHashes[pos]
 	}
 
-	var right *wire.ShaHash
+	var right *chainhash.Hash
 	left := m.calcHash(height-1, pos*2)
 	if pos*2+1 < m.calcTreeWidth(height-1) {
 		right = m.calcHash(height-1, pos*2+1)
@@ -82,7 +83,7 @@ func NewMerkleBlock(block *btcutil.Block, filter *Filter) (*wire.MsgMerkleBlock,
 	numTx := uint32(len(block.Transactions()))
 	mBlock := merkleBlock{
 		numTx:       numTx,
-		allHashes:   make([]*wire.ShaHash, 0, numTx),
+		allHashes:   make([]*chainhash.Hash, 0, numTx),
 		matchedBits: make([]byte, 0, numTx),
 	}
 
@@ -95,7 +96,7 @@ func NewMerkleBlock(block *btcutil.Block, filter *Filter) (*wire.MsgMerkleBlock,
 		} else {
 			mBlock.matchedBits = append(mBlock.matchedBits, 0x00)
 		}
-		mBlock.allHashes = append(mBlock.allHashes, tx.Sha())
+		mBlock.allHashes = append(mBlock.allHashes, tx.Hash())
 	}
 
 	// Calculate the number of merkle branches (height) in the tree.
@@ -111,11 +112,11 @@ func NewMerkleBlock(block *btcutil.Block, filter *Filter) (*wire.MsgMerkleBlock,
 	msgMerkleBlock := wire.MsgMerkleBlock{
 		Header:       block.MsgBlock().Header,
 		Transactions: uint32(mBlock.numTx),
-		Hashes:       make([]*wire.ShaHash, 0, len(mBlock.finalHashes)),
+		Hashes:       make([]*chainhash.Hash, 0, len(mBlock.finalHashes)),
 		Flags:        make([]byte, (len(mBlock.bits)+7)/8),
 	}
-	for _, sha := range mBlock.finalHashes {
-		msgMerkleBlock.AddTxHash(sha)
+	for _, hash := range mBlock.finalHashes {
+		msgMerkleBlock.AddTxHash(hash)
 	}
 	for i := uint32(0); i < uint32(len(mBlock.bits)); i++ {
 		msgMerkleBlock.Flags[i/8] |= mBlock.bits[i] << (i % 8)

--- a/bloom/merkleblock_test.go
+++ b/bloom/merkleblock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/bloom"
@@ -37,13 +38,13 @@ func TestMerkleBlock3(t *testing.T) {
 	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
 
 	inputStr := "63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"
-	sha, err := wire.NewShaHashFromStr(inputStr)
+	hash, err := chainhash.NewHashFromStr(inputStr)
 	if err != nil {
-		t.Errorf("TestMerkleBlock3 NewShaHashFromStr failed: %v", err)
+		t.Errorf("TestMerkleBlock3 NewHashFromStr failed: %v", err)
 		return
 	}
 
-	f.AddShaHash(sha)
+	f.AddHash(hash)
 
 	mBlock, _ := bloom.NewMerkleBlock(blk, f)
 

--- a/coinset/coins.go
+++ b/coinset/coins.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package coinset
 
 import (
@@ -5,13 +9,14 @@ import (
 	"errors"
 	"sort"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
 
 // Coin represents a spendable transaction outpoint
 type Coin interface {
-	Hash() *wire.ShaHash
+	Hash() *chainhash.Hash
 	Index() uint32
 	Value() btcutil.Amount
 	PkScript() []byte
@@ -354,8 +359,8 @@ type SimpleCoin struct {
 var _ Coin = &SimpleCoin{}
 
 // Hash returns the hash value of the transaction on which the Coin is an output
-func (c *SimpleCoin) Hash() *wire.ShaHash {
-	return c.Tx.Sha()
+func (c *SimpleCoin) Hash() *chainhash.Hash {
+	return c.Tx.Hash()
 }
 
 // Index returns the index of the output on the transaction which the Coin represents

--- a/coinset/coins_test.go
+++ b/coinset/coins_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package coinset_test
 
 import (
@@ -6,20 +10,20 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/coinset"
 	"github.com/btcsuite/fastsha256"
 )
 
 type TestCoin struct {
-	TxHash     *wire.ShaHash
+	TxHash     *chainhash.Hash
 	TxIndex    uint32
 	TxValue    btcutil.Amount
 	TxNumConfs int64
 }
 
-func (c *TestCoin) Hash() *wire.ShaHash   { return c.TxHash }
+func (c *TestCoin) Hash() *chainhash.Hash { return c.TxHash }
 func (c *TestCoin) Index() uint32         { return c.TxIndex }
 func (c *TestCoin) Value() btcutil.Amount { return c.TxValue }
 func (c *TestCoin) PkScript() []byte      { return nil }
@@ -29,7 +33,7 @@ func (c *TestCoin) ValueAge() int64       { return int64(c.TxValue) * c.TxNumCon
 func NewCoin(index int64, value btcutil.Amount, numConfs int64) coinset.Coin {
 	h := fastsha256.New()
 	h.Write([]byte(fmt.Sprintf("%d", index)))
-	hash, _ := wire.NewShaHash(h.Sum(nil))
+	hash, _ := chainhash.NewHash(h.Sum(nil))
 	c := &TestCoin{
 		TxHash:     hash,
 		TxIndex:    0,

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -20,7 +20,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/base58"
 )
@@ -395,7 +395,7 @@ func (k *ExtendedKey) String() string {
 		serializedBytes = append(serializedBytes, k.pubKeyBytes()...)
 	}
 
-	checkSum := wire.DoubleSha256(serializedBytes)[:4]
+	checkSum := chainhash.DoubleHashB(serializedBytes)[:4]
 	serializedBytes = append(serializedBytes, checkSum...)
 	return base58.Encode(serializedBytes)
 }
@@ -496,7 +496,7 @@ func NewKeyFromString(key string) (*ExtendedKey, error) {
 	// Split the payload and checksum up and ensure the checksum matches.
 	payload := decoded[:len(decoded)-4]
 	checkSum := decoded[len(decoded)-4:]
-	expectedCheckSum := wire.DoubleSha256(payload)[:4]
+	expectedCheckSum := chainhash.DoubleHashB(payload)[:4]
 	if !bytes.Equal(checkSum, expectedCheckSum) {
 		return nil, ErrBadChecksum
 	}

--- a/tx.go
+++ b/tx.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -21,9 +22,9 @@ const TxIndexUnknown = -1
 // transaction on its first access so subsequent accesses don't have to repeat
 // the relatively expensive hashing operations.
 type Tx struct {
-	msgTx   *wire.MsgTx   // Underlying MsgTx
-	txSha   *wire.ShaHash // Cached transaction hash
-	txIndex int           // Position within a block or TxIndexUnknown
+	msgTx   *wire.MsgTx     // Underlying MsgTx
+	txHash  *chainhash.Hash // Cached transaction hash
+	txIndex int             // Position within a block or TxIndexUnknown
 }
 
 // MsgTx returns the underlying wire.MsgTx for the transaction.
@@ -32,19 +33,19 @@ func (t *Tx) MsgTx() *wire.MsgTx {
 	return t.msgTx
 }
 
-// Sha returns the hash of the transaction.  This is equivalent to
-// calling TxSha on the underlying wire.MsgTx, however it caches the
+// Hash returns the hash of the transaction.  This is equivalent to
+// calling TxHash on the underlying wire.MsgTx, however it caches the
 // result so subsequent calls are more efficient.
-func (t *Tx) Sha() *wire.ShaHash {
+func (t *Tx) Hash() *chainhash.Hash {
 	// Return the cached hash if it has already been generated.
-	if t.txSha != nil {
-		return t.txSha
+	if t.txHash != nil {
+		return t.txHash
 	}
 
 	// Cache the hash and return it.
-	sha := t.msgTx.TxSha()
-	t.txSha = &sha
-	return &sha
+	hash := t.msgTx.TxHash()
+	t.txHash = &hash
+	return &hash
 }
 
 // Index returns the saved index of the transaction within a block.  This value

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
 )
@@ -35,18 +35,18 @@ func TestTx(t *testing.T) {
 	}
 
 	// Hash for block 100,000 transaction 0.
-	wantShaStr := "8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87"
-	wantSha, err := wire.NewShaHashFromStr(wantShaStr)
+	wantHashStr := "8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87"
+	wantHash, err := chainhash.NewHashFromStr(wantHashStr)
 	if err != nil {
-		t.Errorf("NewShaHashFromStr: %v", err)
+		t.Errorf("NewHashFromStr: %v", err)
 	}
 
-	// Request the sha multiple times to test generation and caching.
+	// Request the hash multiple times to test generation and caching.
 	for i := 0; i < 2; i++ {
-		sha := tx.Sha()
-		if !sha.IsEqual(wantSha) {
-			t.Errorf("Sha #%d mismatched sha - got %v, want %v", i,
-				sha, wantSha)
+		hash := tx.Hash()
+		if !hash.IsEqual(wantHash) {
+			t.Errorf("Hash #%d mismatched hash - got %v, want %v", i,
+				hash, wantHash)
 		}
 	}
 }

--- a/txsort/txsort.go
+++ b/txsort/txsort.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"sort"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -76,7 +77,7 @@ func (s sortableInputSlice) Less(i, j int) bool {
 
 	// At this point, the hashes are not equal, so reverse them to
 	// big-endian and return the result of the comparison.
-	const hashSize = wire.HashSize
+	const hashSize = chainhash.HashSize
 	for b := 0; b < hashSize/2; b++ {
 		ihash[b], ihash[hashSize-1-b] = ihash[hashSize-1-b], ihash[b]
 		jhash[b], jhash[hashSize-1-b] = jhash[hashSize-1-b], jhash[b]

--- a/txsort/txsort_test.go
+++ b/txsort/txsort_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -96,7 +96,7 @@ func TestSort(t *testing.T) {
 		// Sort the transaction and ensure the resulting hash is the
 		// expected value.
 		sortedTx := txsort.Sort(&tx)
-		if got := sortedTx.TxSha().String(); got != test.sortedHash {
+		if got := sortedTx.TxHash().String(); got != test.sortedHash {
 			t.Errorf("Sort (%s): sorted hash does not match "+
 				"expected - got %v, want %v", test.name, got,
 				test.sortedHash)
@@ -104,7 +104,7 @@ func TestSort(t *testing.T) {
 		}
 
 		// Ensure the original transaction is not modified.
-		if got := tx.TxSha().String(); got != test.unsortedHash {
+		if got := tx.TxHash().String(); got != test.unsortedHash {
 			t.Errorf("Sort (%s): unsorted hash does not match "+
 				"expected - got %v, want %v", test.name, got,
 				test.unsortedHash)
@@ -114,7 +114,7 @@ func TestSort(t *testing.T) {
 		// Now sort the transaction using the mutable version and ensure
 		// the resulting hash is the expected value.
 		txsort.InPlaceSort(&tx)
-		if got := tx.TxSha().String(); got != test.sortedHash {
+		if got := tx.TxHash().String(); got != test.sortedHash {
 			t.Errorf("SortMutate (%s): sorted hash does not match "+
 				"expected - got %v, want %v", test.name, got,
 				test.sortedHash)

--- a/wif.go
+++ b/wif.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, 2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,7 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil/base58"
 )
 
@@ -110,7 +110,7 @@ func DecodeWIF(wif string) (*WIF, error) {
 	} else {
 		tosum = decoded[:1+btcec.PrivKeyBytesLen]
 	}
-	cksum := wire.DoubleSha256(tosum)[:4]
+	cksum := chainhash.DoubleHashB(tosum)[:4]
 	if !bytes.Equal(cksum, decoded[decodedLen-4:]) {
 		return nil, ErrChecksumMismatch
 	}
@@ -142,7 +142,7 @@ func (w *WIF) String() string {
 	if w.CompressPubKey {
 		a = append(a, compressMagic)
 	}
-	cksum := wire.DoubleSha256(a)[:4]
+	cksum := chainhash.DoubleHashB(a)[:4]
 	a = append(a, cksum...)
 	return base58.Encode(a)
 }


### PR DESCRIPTION
**This PR requires btcsuite/btcd#729.**

This updates all code in the main package and subpackages to make use of the new `chainhash` package since the old `wire.ShaHash` type and functions have been removed in favor of the abstracted package.

Also, since this required API changes anyways and the hash algorithm is no longer tied specifically to SHA, all other functions throughout the code base which had `Sha` in their name have been changed to `Hash` so they are not incorrectly implying the hash algorithm.

The following is an overview of the changes:

- Update all references to `wire.ShaHash` to the new `chainhash.Hash` type
- Rename the following functions and update all references:
  - `Block.Sha` -> `Hash`
  - `Block.TxSha` -> `TxHash`
  - `Tx.Sha` -> `Hash`
  - `bloom.Filter.AddShaHash` -> `AddHash`
- Rename all variables that included `sha` in their name to include `hash` instead
- Add license headers to `coinset` package files

**NOTE:** This PR will fail the CI build because it depends on the aforementioned btcd PR.