### PR TITLE
use fast base58 encode implementation (20~60% performance gain)

### DIFF
--- a/base58/base58_test.go
+++ b/base58/base58_test.go
@@ -60,6 +60,7 @@ var hexTests = []struct {
 	{"ecac89cad93923c02321", "EJDM8drfXA6uyA"},
 	{"10c8511e", "Rt5zm"},
 	{"00000000000000000000", "1111111111"},
+	{"5b00a0025e4a16612af5a7960eabf7017719f0feeba37435ee291641d652f84dc7f054ccdac136364761d1055c04a26d301567d5598402a2937e5105d2d27bef", "2pXZgXTZ3ATFxvL3fr5TztiVUyjhJ1TYDTk4CP2Fayz2Chb9Ud5zRa3iaDSkfbs5DorAznRZi94RXnXoQ3qUB4Kp"},
 }
 
 func TestBase58(t *testing.T) {


### PR DESCRIPTION
```
$ go test -bench=. base58/base58bench_test.go 
BenchmarkBase58FastEncode-7        	      30	  45674986 ns/op	   0.11 MB/s
BenchmarkBase58SlowEncode-7        	      20	  63573231 ns/op	   0.08 MB/s
BenchmarkBase58FastEncodeSmall-7   	 1000000	      1712 ns/op	  17.52 MB/s
BenchmarkBase58SlowEncodeSmall-7   	  300000	      5336 ns/op	   5.62 MB/s
BenchmarkBase58Decode-7            	     300	   5276054 ns/op	   1.29 MB/s
```