### PR TITLE
multi: Update markdown files for GFM changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 btcutil
 =======
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
-(https://travis-ci.org/btcsuite/btcutil) [![Coverage Status]
-(http://img.shields.io/coveralls/btcsuite/btcutil.svg)]
-(https://coveralls.io/r/btcsuite/btcutil?branch=master) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcutil)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)](https://travis-ci.org/btcsuite/btcutil)
+[![Coverage Status](http://img.shields.io/coveralls/btcsuite/btcutil.svg)](https://coveralls.io/r/btcsuite/btcutil?branch=master)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcutil)
 
 Package btcutil provides bitcoin-specific convenience functions and types.
 A comprehensive suite of tests is provided to ensure proper functionality.  See

--- a/base58/README.md
+++ b/base58/README.md
@@ -1,11 +1,9 @@
 base58
 ==========
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
-(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcutil/base58?status.png)]
-(http://godoc.org/github.com/btcsuite/btcutil/base58)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)](https://travis-ci.org/btcsuite/btcutil)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcutil/base58)
 
 Package base58 provides an API for encoding and decoding to and from the
 modified base58 encoding.  It also provides an API to do Base58Check encoding,
@@ -21,17 +19,13 @@ $ go get -u github.com/btcsuite/btcutil/base58
 
 ## Examples
 
-* [Decode Example]
-  (http://godoc.org/github.com/btcsuite/btcutil/base58#example-Decode)  
+* [Decode Example](http://godoc.org/github.com/btcsuite/btcutil/base58#example-Decode)  
   Demonstrates how to decode modified base58 encoded data.
-* [Encode Example]
-  (http://godoc.org/github.com/btcsuite/btcutil/base58#example-Encode)  
+* [Encode Example](http://godoc.org/github.com/btcsuite/btcutil/base58#example-Encode)  
   Demonstrates how to encode data using the modified base58 encoding scheme.
-* [CheckDecode Example]
-  (http://godoc.org/github.com/btcsuite/btcutil/base58#example-CheckDecode)  
+* [CheckDecode Example](http://godoc.org/github.com/btcsuite/btcutil/base58#example-CheckDecode)  
   Demonstrates how to decode Base58Check encoded data.
-* [CheckEncode Example]
-  (http://godoc.org/github.com/btcsuite/btcutil/base58#example-CheckEncode)  
+* [CheckEncode Example](http://godoc.org/github.com/btcsuite/btcutil/base58#example-CheckEncode)  
   Demonstrates how to encode data using the Base58Check encoding scheme.
 
 ## License

--- a/bloom/README.md
+++ b/bloom/README.md
@@ -1,11 +1,9 @@
 bloom
 =====
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
-(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcutil/bloom)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)](https://travis-ci.org/btcsuite/btcutil)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcutil/bloom)
 
 Package bloom provides an API for dealing with bitcoin-specific bloom filters.
 
@@ -22,8 +20,7 @@ $ go get -u github.com/btcsuite/btcutil/bloom
 
 ## Examples
 
-* [NewFilter Example]
-  (http://godoc.org/github.com/btcsuite/btcutil/bloom#example-NewFilter)  
+* [NewFilter Example](http://godoc.org/github.com/btcsuite/btcutil/bloom#example-NewFilter)  
   Demonstrates how to create a new bloom filter, add a transaction hash to it,
   and check if the filter matches the transaction.
 

--- a/coinset/README.md
+++ b/coinset/README.md
@@ -1,11 +1,9 @@
 coinset
 =======
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
-(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcutil/coinset)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)](https://travis-ci.org/btcsuite/btcutil)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcutil/coinset)
 
 Package coinset provides bitcoin-specific convenience functions for selecting
 from and managing sets of unspent transaction outpoints (UTXOs).

--- a/hdkeychain/README.md
+++ b/hdkeychain/README.md
@@ -1,11 +1,9 @@
 hdkeychain
 ==========
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
-(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcutil/hdkeychain)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)](https://travis-ci.org/btcsuite/btcutil)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcutil/hdkeychain)
 
 Package hdkeychain provides an API for bitcoin hierarchical deterministic
 extended keys (BIP0032).
@@ -46,16 +44,13 @@ $ go get -u github.com/btcsuite/btcutil/hdkeychain
 
 ## Examples
 
-* [NewMaster Example]
-  (http://godoc.org/github.com/btcsuite/btcutil/hdkeychain#example-NewMaster)  
+* [NewMaster Example](http://godoc.org/github.com/btcsuite/btcutil/hdkeychain#example-NewMaster)  
   Demonstrates how to generate a cryptographically random seed then use it to
   create a new master node (extended key).
-* [Default Wallet Layout Example]
-  (http://godoc.org/github.com/btcsuite/btcutil/hdkeychain#example-package--DefaultWalletLayout)  
+* [Default Wallet Layout Example](http://godoc.org/github.com/btcsuite/btcutil/hdkeychain#example-package--DefaultWalletLayout)  
   Demonstrates the default hierarchical deterministic wallet layout as described
   in BIP0032.
-* [Audits Use Case Example]
-  (http://godoc.org/github.com/btcsuite/btcutil/hdkeychain#example-package--Audits)  
+* [Audits Use Case Example](http://godoc.org/github.com/btcsuite/btcutil/hdkeychain#example-package--Audits)  
   Demonstrates the audits use case in BIP0032.
 
 ## License

--- a/txsort/README.md
+++ b/txsort/README.md
@@ -1,11 +1,9 @@
 txsort
 ======
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)]
-(https://travis-ci.org/btcsuite/btcutil) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcutil/txsort)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)](https://travis-ci.org/btcsuite/btcutil)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcutil/txsort)
 
 Package txsort provides the transaction sorting according to [BIP 69](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki).
 


### PR DESCRIPTION
The github markdown interpreter has been changed such that it no longer allows spaces in between the brackets and parenthesis of links.  This updates all of the markdown files accordingly.

While here, it also corrects a couple of inconsistencies in regards to other `README.md` files in the project.