### PR TITLE
Add Bech32 address format package.

### DIFF
--- a/address.go
+++ b/address.go
@@ -5,14 +5,34 @@
 package btcutil
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil/base58"
+	"github.com/btcsuite/btcutil/bech32"
 	"golang.org/x/crypto/ripemd160"
 )
+
+// UnsupportedWitnessVerError describes an error where a segwit address being
+// decoded has an unsupported witness version.
+type UnsupportedWitnessVerError byte
+
+func (e UnsupportedWitnessVerError) Error() string {
+	return "unsupported witness version: " + string(e)
+}
+
+// UnsupportedWitnessProgLenError describes an error where a segwit address
+// being decoded has an unsupported witness program length.
+type UnsupportedWitnessProgLenError int
+
+func (e UnsupportedWitnessProgLenError) Error() string {
+	return "unsupported witness program length: " + string(e)
+}
 
 var (
 	// ErrChecksumMismatch describes an error where decoding failed due
@@ -42,6 +62,39 @@ func encodeAddress(hash160 []byte, netID byte) string {
 	// Format is 1 byte for a network and address class (i.e. P2PKH vs
 	// P2SH), 20 bytes for a RIPEMD160 hash, and 4 bytes of checksum.
 	return base58.CheckEncode(hash160[:ripemd160.Size], netID)
+}
+
+// encodeSegWitAddress creates a bech32 encoded address string representation
+// from witness version and witness program.
+func encodeSegWitAddress(hrp string, witnessVersion byte, witnessProgram []byte) (string, error) {
+	// Group the address bytes into 5 bit groups, as this is what is used to
+	// encode each character in the address string.
+	converted, err := bech32.ConvertBits(witnessProgram, 8, 5, true)
+	if err != nil {
+		return "", err
+	}
+
+	// Concatenate the witness version and program, and encode the resulting
+	// bytes using bech32 encoding.
+	combined := make([]byte, len(converted)+1)
+	combined[0] = witnessVersion
+	copy(combined[1:], converted)
+	bech, err := bech32.Encode(hrp, combined)
+	if err != nil {
+		return "", err
+	}
+
+	// Check validity by decoding the created address.
+	version, program, err := decodeSegWitAddress(bech)
+	if err != nil {
+		return "", fmt.Errorf("invalid segwit address: %v", err)
+	}
+
+	if version != witnessVersion || !bytes.Equal(program, witnessProgram) {
+		return "", fmt.Errorf("invalid segwit address")
+	}
+
+	return bech, nil
 }
 
 // Address is an interface type for any type of destination a transaction
@@ -81,6 +134,40 @@ type Address interface {
 // When the address does not encode the network, such as in the case of a raw
 // public key, the address will be associated with the passed defaultNet.
 func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
+	// Bech32 encoded segwit addresses start with a human-readable part
+	// (hrp) followed by '1'. For Bitcoin mainnet the hrp is "bc", and for
+	// testnet it is "tb". If the address string has a prefix that matches
+	// one of the prefixes for the known networks, we try to decode it as
+	// a segwit address.
+	oneIndex := strings.LastIndexByte(addr, '1')
+	if oneIndex > 1 {
+		prefix := addr[:oneIndex+1]
+		if chaincfg.IsBech32SegwitPrefix(prefix) {
+			witnessVer, witnessProg, err := decodeSegWitAddress(addr)
+			if err != nil {
+				return nil, err
+			}
+
+			// We currently only support P2WPKH and P2WSH, which is
+			// witness version 0.
+			if witnessVer != 0 {
+				return nil, UnsupportedWitnessVerError(witnessVer)
+			}
+
+			// The HRP is everything before the found '1'.
+			hrp := prefix[:len(prefix)-1]
+
+			switch len(witnessProg) {
+			case 20:
+				return newAddressWitnessPubKeyHash(hrp, witnessProg)
+			case 32:
+				return newAddressWitnessScriptHash(hrp, witnessProg)
+			default:
+				return nil, UnsupportedWitnessProgLenError(len(witnessProg))
+			}
+		}
+	}
+
 	// Serialized public keys are either 65 bytes (130 hex chars) if
 	// uncompressed/hybrid or 33 bytes (66 hex chars) if compressed.
 	if len(addr) == 130 || len(addr) == 66 {
@@ -117,6 +204,49 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 	default:
 		return nil, errors.New("decoded address is of unknown size")
 	}
+}
+
+// decodeSegWitAddress parses a bech32 encoded segwit address string and
+// returns the witness version and witness program byte representation.
+func decodeSegWitAddress(address string) (byte, []byte, error) {
+	// Decode the bech32 encoded address.
+	_, data, err := bech32.Decode(address)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	// The first byte of the decoded address is the witness version, it must
+	// exist.
+	if len(data) < 1 {
+		return 0, nil, fmt.Errorf("no witness version")
+	}
+
+	// ...and be <= 16.
+	version := data[0]
+	if version > 16 {
+		return 0, nil, fmt.Errorf("invalid witness version: %v", version)
+	}
+
+	// The remaining characters of the address returned are grouped into
+	// words of 5 bits. In order to restore the original witness program
+	// bytes, we'll need to regroup into 8 bit words.
+	regrouped, err := bech32.ConvertBits(data[1:], 5, 8, false)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	// The regrouped data must be between 2 and 40 bytes.
+	if len(regrouped) < 2 || len(regrouped) > 40 {
+		return 0, nil, fmt.Errorf("invalid data length")
+	}
+
+	// For witness version 0, address MUST be exactly 20 or 32 bytes.
+	if version == 0 && len(regrouped) != 20 && len(regrouped) != 32 {
+		return 0, nil, fmt.Errorf("invalid data length for witness "+
+			"version 0: %v", len(regrouped))
+	}
+
+	return version, regrouped, nil
 }
 
 // AddressPubKeyHash is an Address for a pay-to-pubkey-hash (P2PKH)
@@ -374,4 +504,180 @@ func (a *AddressPubKey) AddressPubKeyHash() *AddressPubKeyHash {
 // PubKey returns the underlying public key for the address.
 func (a *AddressPubKey) PubKey() *btcec.PublicKey {
 	return a.pubKey
+}
+
+// AddressWitnessPubKeyHash is an Address for a pay-to-witness-pubkey-hash
+// (P2WPKH) output. See BIP 173 for further details regarding native segregated
+// witness address encoding:
+// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+type AddressWitnessPubKeyHash struct {
+	hrp            string
+	witnessVersion byte
+	witnessProgram [20]byte
+}
+
+// NewAddressWitnessPubKeyHash returns a new AddressWitnessPubKeyHash.
+func NewAddressWitnessPubKeyHash(witnessProg []byte, net *chaincfg.Params) (*AddressWitnessPubKeyHash, error) {
+	return newAddressWitnessPubKeyHash(net.Bech32HRPSegwit, witnessProg)
+}
+
+// newAddressWitnessPubKeyHash is an internal helper function to create an
+// AddressWitnessPubKeyHash with a known human-readable part, rather than
+// looking it up through its parameters.
+func newAddressWitnessPubKeyHash(hrp string, witnessProg []byte) (*AddressWitnessPubKeyHash, error) {
+	// Check for valid program length for witness version 0, which is 20
+	// for P2WPKH.
+	if len(witnessProg) != 20 {
+		return nil, errors.New("witness program must be 20 " +
+			"bytes for p2wpkh")
+	}
+
+	addr := &AddressWitnessPubKeyHash{
+		hrp:            strings.ToLower(hrp),
+		witnessVersion: 0x00,
+	}
+
+	copy(addr.witnessProgram[:], witnessProg)
+
+	return addr, nil
+}
+
+// EncodeAddress returns the bech32 string encoding of an
+// AddressWitnessPubKeyHash.
+// Part of the Address interface.
+func (a *AddressWitnessPubKeyHash) EncodeAddress() string {
+	str, err := encodeSegWitAddress(a.hrp, a.witnessVersion,
+		a.witnessProgram[:])
+	if err != nil {
+		return ""
+	}
+	return str
+}
+
+// ScriptAddress returns the witness program for this address.
+// Part of the Address interface.
+func (a *AddressWitnessPubKeyHash) ScriptAddress() []byte {
+	return a.witnessProgram[:]
+}
+
+// IsForNet returns whether or not the AddressWitnessPubKeyHash is associated
+// with the passed bitcoin network.
+// Part of the Address interface.
+func (a *AddressWitnessPubKeyHash) IsForNet(net *chaincfg.Params) bool {
+	return a.hrp == net.Bech32HRPSegwit
+}
+
+// String returns a human-readable string for the AddressWitnessPubKeyHash.
+// This is equivalent to calling EncodeAddress, but is provided so the type
+// can be used as a fmt.Stringer.
+// Part of the Address interface.
+func (a *AddressWitnessPubKeyHash) String() string {
+	return a.EncodeAddress()
+}
+
+// Hrp returns the human-readable part of the bech32 encoded
+// AddressWitnessPubKeyHash.
+func (a *AddressWitnessPubKeyHash) Hrp() string {
+	return a.hrp
+}
+
+// WitnessVersion returns the witness version of the AddressWitnessPubKeyHash.
+func (a *AddressWitnessPubKeyHash) WitnessVersion() byte {
+	return a.witnessVersion
+}
+
+// WitnessProgram returns the witness program of the AddressWitnessPubKeyHash.
+func (a *AddressWitnessPubKeyHash) WitnessProgram() []byte {
+	return a.witnessProgram[:]
+}
+
+// Hash160 returns the witness program of the AddressWitnessPubKeyHash as a
+// byte array.
+func (a *AddressWitnessPubKeyHash) Hash160() *[20]byte {
+	return &a.witnessProgram
+}
+
+// AddressWitnessScriptHash is an Address for a pay-to-witness-script-hash
+// (P2WSH) output. See BIP 173 for further details regarding native segregated
+// witness address encoding:
+// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+type AddressWitnessScriptHash struct {
+	hrp            string
+	witnessVersion byte
+	witnessProgram [32]byte
+}
+
+// NewAddressWitnessScriptHash returns a new AddressWitnessPubKeyHash.
+func NewAddressWitnessScriptHash(witnessProg []byte, net *chaincfg.Params) (*AddressWitnessScriptHash, error) {
+	return newAddressWitnessScriptHash(net.Bech32HRPSegwit, witnessProg)
+}
+
+// newAddressWitnessScriptHash is an internal helper function to create an
+// AddressWitnessScriptHash with a known human-readable part, rather than
+// looking it up through its parameters.
+func newAddressWitnessScriptHash(hrp string, witnessProg []byte) (*AddressWitnessScriptHash, error) {
+	// Check for valid program length for witness version 0, which is 32
+	// for P2WSH.
+	if len(witnessProg) != 32 {
+		return nil, errors.New("witness program must be 32 " +
+			"bytes for p2wsh")
+	}
+
+	addr := &AddressWitnessScriptHash{
+		hrp:            strings.ToLower(hrp),
+		witnessVersion: 0x00,
+	}
+
+	copy(addr.witnessProgram[:], witnessProg)
+
+	return addr, nil
+}
+
+// EncodeAddress returns the bech32 string encoding of an
+// AddressWitnessScriptHash.
+// Part of the Address interface.
+func (a *AddressWitnessScriptHash) EncodeAddress() string {
+	str, err := encodeSegWitAddress(a.hrp, a.witnessVersion,
+		a.witnessProgram[:])
+	if err != nil {
+		return ""
+	}
+	return str
+}
+
+// ScriptAddress returns the witness program for this address.
+// Part of the Address interface.
+func (a *AddressWitnessScriptHash) ScriptAddress() []byte {
+	return a.witnessProgram[:]
+}
+
+// IsForNet returns whether or not the AddressWitnessScriptHash is associated
+// with the passed bitcoin network.
+// Part of the Address interface.
+func (a *AddressWitnessScriptHash) IsForNet(net *chaincfg.Params) bool {
+	return a.hrp == net.Bech32HRPSegwit
+}
+
+// String returns a human-readable string for the AddressWitnessScriptHash.
+// This is equivalent to calling EncodeAddress, but is provided so the type
+// can be used as a fmt.Stringer.
+// Part of the Address interface.
+func (a *AddressWitnessScriptHash) String() string {
+	return a.EncodeAddress()
+}
+
+// Hrp returns the human-readable part of the bech32 encoded
+// AddressWitnessScriptHash.
+func (a *AddressWitnessScriptHash) Hrp() string {
+	return a.hrp
+}
+
+// WitnessVersion returns the witness version of the AddressWitnessScriptHash.
+func (a *AddressWitnessScriptHash) WitnessVersion() byte {
+	return a.witnessVersion
+}
+
+// WitnessProgram returns the witness program of the AddressWitnessScriptHash.
+func (a *AddressWitnessScriptHash) WitnessProgram() []byte {
+	return a.witnessProgram[:]
 }

--- a/address_test.go
+++ b/address_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -94,11 +95,13 @@ func TestAddresses(t *testing.T) {
 					0xaa}
 				return btcutil.NewAddressPubKeyHash(pkHash, &chaincfg.MainNetParams)
 			},
+			net: &chaincfg.MainNetParams,
 		},
 		{
 			name:  "p2pkh bad checksum",
 			addr:  "1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gY",
 			valid: false,
+			net:   &chaincfg.MainNetParams,
 		},
 
 		// Positive P2SH tests.
@@ -195,6 +198,7 @@ func TestAddresses(t *testing.T) {
 					0x10}
 				return btcutil.NewAddressScriptHashFromHash(hash, &chaincfg.MainNetParams)
 			},
+			net: &chaincfg.MainNetParams,
 		},
 
 		// Positive P2PK tests.
@@ -460,6 +464,188 @@ func TestAddresses(t *testing.T) {
 			},
 			net: &chaincfg.TestNet3Params,
 		},
+		// Segwit address tests.
+		{
+			name:    "segwit mainnet p2wpkh v0",
+			addr:    "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
+			encoded: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+			valid:   true,
+			result: btcutil.TstAddressWitnessPubKeyHash(
+				0,
+				[20]byte{
+					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
+					0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6},
+				chaincfg.MainNetParams.Bech32HRPSegwit),
+			f: func() (btcutil.Address, error) {
+				pkHash := []byte{
+					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
+					0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6}
+				return btcutil.NewAddressWitnessPubKeyHash(pkHash, &chaincfg.MainNetParams)
+			},
+			net: &chaincfg.MainNetParams,
+		},
+		{
+			name:    "segwit mainnet p2wsh v0",
+			addr:    "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+			encoded: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+			valid:   true,
+			result: btcutil.TstAddressWitnessScriptHash(
+				0,
+				[32]byte{
+					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
+					0x04, 0xbd, 0x19, 0x20, 0x33, 0x56, 0xda, 0x13,
+					0x6c, 0x98, 0x56, 0x78, 0xcd, 0x4d, 0x27, 0xa1,
+					0xb8, 0xc6, 0x32, 0x96, 0x04, 0x90, 0x32, 0x62},
+				chaincfg.MainNetParams.Bech32HRPSegwit),
+			f: func() (btcutil.Address, error) {
+				scriptHash := []byte{
+					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
+					0x04, 0xbd, 0x19, 0x20, 0x33, 0x56, 0xda, 0x13,
+					0x6c, 0x98, 0x56, 0x78, 0xcd, 0x4d, 0x27, 0xa1,
+					0xb8, 0xc6, 0x32, 0x96, 0x04, 0x90, 0x32, 0x62}
+				return btcutil.NewAddressWitnessScriptHash(scriptHash, &chaincfg.MainNetParams)
+			},
+			net: &chaincfg.MainNetParams,
+		},
+		{
+			name:    "segwit testnet p2wpkh v0",
+			addr:    "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+			encoded: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+			valid:   true,
+			result: btcutil.TstAddressWitnessPubKeyHash(
+				0,
+				[20]byte{
+					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
+					0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6},
+				chaincfg.TestNet3Params.Bech32HRPSegwit),
+			f: func() (btcutil.Address, error) {
+				pkHash := []byte{
+					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
+					0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6}
+				return btcutil.NewAddressWitnessPubKeyHash(pkHash, &chaincfg.TestNet3Params)
+			},
+			net: &chaincfg.TestNet3Params,
+		},
+		{
+			name:    "segwit testnet p2wsh v0",
+			addr:    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+			encoded: "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+			valid:   true,
+			result: btcutil.TstAddressWitnessScriptHash(
+				0,
+				[32]byte{
+					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
+					0x04, 0xbd, 0x19, 0x20, 0x33, 0x56, 0xda, 0x13,
+					0x6c, 0x98, 0x56, 0x78, 0xcd, 0x4d, 0x27, 0xa1,
+					0xb8, 0xc6, 0x32, 0x96, 0x04, 0x90, 0x32, 0x62},
+				chaincfg.TestNet3Params.Bech32HRPSegwit),
+			f: func() (btcutil.Address, error) {
+				scriptHash := []byte{
+					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
+					0x04, 0xbd, 0x19, 0x20, 0x33, 0x56, 0xda, 0x13,
+					0x6c, 0x98, 0x56, 0x78, 0xcd, 0x4d, 0x27, 0xa1,
+					0xb8, 0xc6, 0x32, 0x96, 0x04, 0x90, 0x32, 0x62}
+				return btcutil.NewAddressWitnessScriptHash(scriptHash, &chaincfg.TestNet3Params)
+			},
+			net: &chaincfg.TestNet3Params,
+		},
+		{
+			name:    "segwit testnet p2wsh witness v0",
+			addr:    "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+			encoded: "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+			valid:   true,
+			result: btcutil.TstAddressWitnessScriptHash(
+				0,
+				[32]byte{
+					0x00, 0x00, 0x00, 0xc4, 0xa5, 0xca, 0xd4, 0x62,
+					0x21, 0xb2, 0xa1, 0x87, 0x90, 0x5e, 0x52, 0x66,
+					0x36, 0x2b, 0x99, 0xd5, 0xe9, 0x1c, 0x6c, 0xe2,
+					0x4d, 0x16, 0x5d, 0xab, 0x93, 0xe8, 0x64, 0x33},
+				chaincfg.TestNet3Params.Bech32HRPSegwit),
+			f: func() (btcutil.Address, error) {
+				scriptHash := []byte{
+					0x00, 0x00, 0x00, 0xc4, 0xa5, 0xca, 0xd4, 0x62,
+					0x21, 0xb2, 0xa1, 0x87, 0x90, 0x5e, 0x52, 0x66,
+					0x36, 0x2b, 0x99, 0xd5, 0xe9, 0x1c, 0x6c, 0xe2,
+					0x4d, 0x16, 0x5d, 0xab, 0x93, 0xe8, 0x64, 0x33}
+				return btcutil.NewAddressWitnessScriptHash(scriptHash, &chaincfg.TestNet3Params)
+			},
+			net: &chaincfg.TestNet3Params,
+		},
+		// Unsupported witness versions (version 0 only supported at this point)
+		{
+			name:  "segwit mainnet witness v1",
+			addr:  "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+			valid: false,
+			net:   &chaincfg.MainNetParams,
+		},
+		{
+			name:  "segwit mainnet witness v16",
+			addr:  "BC1SW50QA3JX3S",
+			valid: false,
+			net:   &chaincfg.MainNetParams,
+		},
+		{
+			name:  "segwit mainnet witness v2",
+			addr:  "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
+			valid: false,
+			net:   &chaincfg.MainNetParams,
+		},
+		// Invalid segwit addresses
+		{
+			name:  "segwit invalid hrp",
+			addr:  "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+			valid: false,
+			net:   &chaincfg.TestNet3Params,
+		},
+		{
+			name:  "segwit invalid checksum",
+			addr:  "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+			valid: false,
+			net:   &chaincfg.MainNetParams,
+		},
+		{
+			name:  "segwit invalid witness version",
+			addr:  "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+			valid: false,
+			net:   &chaincfg.MainNetParams,
+		},
+		{
+			name:  "segwit invalid program length",
+			addr:  "bc1rw5uspcuh",
+			valid: false,
+			net:   &chaincfg.MainNetParams,
+		},
+		{
+			name:  "segwit invalid program length",
+			addr:  "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+			valid: false,
+			net:   &chaincfg.MainNetParams,
+		},
+		{
+			name:  "segwit invalid program length for witness version 0 (per BIP141)",
+			addr:  "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+			valid: false,
+			net:   &chaincfg.MainNetParams,
+		},
+		{
+			name:  "segwit mixed case",
+			addr:  "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+			valid: false,
+			net:   &chaincfg.TestNet3Params,
+		},
+		{
+			name:  "segwit zero padding of more than 4 bits",
+			addr:  "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
+			valid: false,
+			net:   &chaincfg.TestNet3Params,
+		},
+		{
+			name:  "segwit non-zero padding in 8-to-5 conversion",
+			addr:  "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+			valid: false,
+			net:   &chaincfg.TestNet3Params,
+		},
 	}
 
 	for _, test := range tests {
@@ -474,7 +660,16 @@ func TestAddresses(t *testing.T) {
 			// Ensure the stringer returns the same address as the
 			// original.
 			if decodedStringer, ok := decoded.(fmt.Stringer); ok {
-				if test.addr != decodedStringer.String() {
+				addr := test.addr
+
+				// For Segwit addresses the string representation
+				// will always be lower case, so in that case we
+				// convert the original to lower case first.
+				if strings.Contains(test.name, "segwit") {
+					addr = strings.ToLower(addr)
+				}
+
+				if addr != decodedStringer.String() {
 					t.Errorf("%v: String on decoded value does not match expected value: %v != %v",
 						test.name, test.addr, decodedStringer.String())
 					return
@@ -502,6 +697,10 @@ func TestAddresses(t *testing.T) {
 				// Ignore the error here since the script
 				// address is checked below.
 				saddr, _ = hex.DecodeString(d.String())
+			case *btcutil.AddressWitnessPubKeyHash:
+				saddr = btcutil.TstAddressSegwitSAddr(encoded)
+			case *btcutil.AddressWitnessScriptHash:
+				saddr = btcutil.TstAddressSegwitSAddr(encoded)
 			}
 
 			// Check script address, as well as the Hash160 method for P2PKH and
@@ -523,6 +722,46 @@ func TestAddresses(t *testing.T) {
 				if h := a.Hash160()[:]; !bytes.Equal(saddr, h) {
 					t.Errorf("%v: hashes do not match:\n%x != \n%x",
 						test.name, saddr, h)
+					return
+				}
+
+			case *btcutil.AddressWitnessPubKeyHash:
+				if hrp := a.Hrp(); test.net.Bech32HRPSegwit != hrp {
+					t.Errorf("%v: hrps do not match:\n%x != \n%x",
+						test.name, test.net.Bech32HRPSegwit, hrp)
+					return
+				}
+
+				expVer := test.result.(*btcutil.AddressWitnessPubKeyHash).WitnessVersion()
+				if v := a.WitnessVersion(); v != expVer {
+					t.Errorf("%v: witness versions do not match:\n%x != \n%x",
+						test.name, expVer, v)
+					return
+				}
+
+				if p := a.WitnessProgram(); !bytes.Equal(saddr, p) {
+					t.Errorf("%v: witness programs do not match:\n%x != \n%x",
+						test.name, saddr, p)
+					return
+				}
+
+			case *btcutil.AddressWitnessScriptHash:
+				if hrp := a.Hrp(); test.net.Bech32HRPSegwit != hrp {
+					t.Errorf("%v: hrps do not match:\n%x != \n%x",
+						test.name, test.net.Bech32HRPSegwit, hrp)
+					return
+				}
+
+				expVer := test.result.(*btcutil.AddressWitnessScriptHash).WitnessVersion()
+				if v := a.WitnessVersion(); v != expVer {
+					t.Errorf("%v: witness versions do not match:\n%x != \n%x",
+						test.name, expVer, v)
+					return
+				}
+
+				if p := a.WitnessProgram(); !bytes.Equal(saddr, p) {
+					t.Errorf("%v: witness programs do not match:\n%x != \n%x",
+						test.name, saddr, p)
 					return
 				}
 			}

--- a/bech32/README.md
+++ b/bech32/README.md
@@ -1,0 +1,29 @@
+bech32
+==========
+
+[![Build Status](http://img.shields.io/travis/btcsuite/btcutil.svg)](https://travis-ci.org/btcsuite/btcutil)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcutil/bech32?status.png)](http://godoc.org/github.com/btcsuite/btcutil/bech32)
+
+Package bech32 provides a Go implementation of the bech32 format specified in
+[BIP 173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki).
+
+Test vectors from BIP 173 are added to ensure compatibility with the BIP.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/btcsuite/btcutil/bech32
+```
+
+## Examples
+
+* [Bech32 decode Example](http://godoc.org/github.com/btcsuite/btcutil/bech32#example-Bech32Decode)
+  Demonstrates how to decode a bech32 encoded string.
+* [Bech32 encode Example](http://godoc.org/github.com/btcsuite/btcutil/bech32#example-BechEncode)
+  Demonstrates how to encode data into a bech32 string.
+
+## License
+
+Package bech32 is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/bech32/bech32.go
+++ b/bech32/bech32.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package bech32
+
+import (
+	"fmt"
+	"strings"
+)
+
+const charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+var gen = []int{0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3}
+
+// Decode decodes a bech32 encoded string, returning the human-readable
+// part and the data part excluding the checksum.
+func Decode(bech string) (string, []byte, error) {
+	// The maximum allowed length for a bech32 string is 90. It must also
+	// be at least 8 characters, since it needs a non-empty HRP, a
+	// separator, and a 6 character checksum.
+	if len(bech) < 8 || len(bech) > 90 {
+		return "", nil, fmt.Errorf("invalid bech32 string length %d",
+			len(bech))
+	}
+	// Only	ASCII characters between 33 and 126 are allowed.
+	for i := 0; i < len(bech); i++ {
+		if bech[i] < 33 || bech[i] > 126 {
+			return "", nil, fmt.Errorf("invalid character in "+
+				"string: '%c'", bech[i])
+		}
+	}
+
+	// The characters must be either all lowercase or all uppercase.
+	lower := strings.ToLower(bech)
+	upper := strings.ToUpper(bech)
+	if bech != lower && bech != upper {
+		return "", nil, fmt.Errorf("string not all lowercase or all " +
+			"uppercase")
+	}
+
+	// We'll work with the lowercase string from now on.
+	bech = lower
+
+	// The string is invalid if the last '1' is non-existent, it is the
+	// first character of the string (no human-readable part) or one of the
+	// last 6 characters of the string (since checksum cannot contain '1'),
+	// or if the string is more than 90 characters in total.
+	one := strings.LastIndexByte(bech, '1')
+	if one < 1 || one+7 > len(bech) {
+		return "", nil, fmt.Errorf("invalid index of 1")
+	}
+
+	// The human-readable part is everything before the last '1'.
+	hrp := bech[:one]
+	data := bech[one+1:]
+
+	// Each character corresponds to the byte with value of the index in
+	// 'charset'.
+	decoded, err := toBytes(data)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed converting data to bytes: "+
+			"%v", err)
+	}
+
+	if !bech32VerifyChecksum(hrp, decoded) {
+		moreInfo := ""
+		checksum := bech[len(bech)-6:]
+		expected, err := toChars(bech32Checksum(hrp,
+			decoded[:len(decoded)-6]))
+		if err == nil {
+			moreInfo = fmt.Sprintf("Expected %v, got %v.",
+				expected, checksum)
+		}
+		return "", nil, fmt.Errorf("checksum failed. " + moreInfo)
+	}
+
+	// We exclude the last 6 bytes, which is the checksum.
+	return hrp, decoded[:len(decoded)-6], nil
+}
+
+// Encode encodes a byte slice into a bech32 string with the
+// human-readable part hrb. Note that the bytes must each encode 5 bits
+// (base32).
+func Encode(hrp string, data []byte) (string, error) {
+	// Calculate the checksum of the data and append it at the end.
+	checksum := bech32Checksum(hrp, data)
+	combined := append(data, checksum...)
+
+	// The resulting bech32 string is the concatenation of the hrp, the
+	// separator 1, data and checksum. Everything after the separator is
+	// represented using the specified charset.
+	dataChars, err := toChars(combined)
+	if err != nil {
+		return "", fmt.Errorf("unable to convert data bytes to chars: "+
+			"%v", err)
+	}
+	return hrp + "1" + dataChars, nil
+}
+
+// toBytes converts each character in the string 'chars' to the value of the
+// index of the correspoding character in 'charset'.
+func toBytes(chars string) ([]byte, error) {
+	decoded := make([]byte, 0, len(chars))
+	for i := 0; i < len(chars); i++ {
+		index := strings.IndexByte(charset, chars[i])
+		if index < 0 {
+			return nil, fmt.Errorf("invalid character not part of "+
+				"charset: %v", chars[i])
+		}
+		decoded = append(decoded, byte(index))
+	}
+	return decoded, nil
+}
+
+// toChars converts the byte slice 'data' to a string where each byte in 'data'
+// encodes the index of a character in 'charset'.
+func toChars(data []byte) (string, error) {
+	result := make([]byte, 0, len(data))
+	for _, b := range data {
+		if int(b) >= len(charset) {
+			return "", fmt.Errorf("invalid data byte: %v", b)
+		}
+		result = append(result, charset[b])
+	}
+	return string(result), nil
+}
+
+// ConvertBits converts a byte slice where each byte is encoding fromBits bits,
+// to a byte slice where each byte is encoding toBits bits.
+func ConvertBits(data []byte, fromBits, toBits uint8, pad bool) ([]byte, error) {
+	if fromBits < 1 || fromBits > 8 || toBits < 1 || toBits > 8 {
+		return nil, fmt.Errorf("only bit groups between 1 and 8 allowed")
+	}
+
+	// The final bytes, each byte encoding toBits bits.
+	var regrouped []byte
+
+	// Keep track of the next byte we create and how many bits we have
+	// added to it out of the toBits goal.
+	nextByte := byte(0)
+	filledBits := uint8(0)
+
+	for _, b := range data {
+
+		// Discard unused bits.
+		b = b << (8 - fromBits)
+
+		// How many bits remaining to extract from the input data.
+		remFromBits := fromBits
+		for remFromBits > 0 {
+			// How many bits remaining to be added to the next byte.
+			remToBits := toBits - filledBits
+
+			// The number of bytes to next extract is the minimum of
+			// remFromBits and remToBits.
+			toExtract := remFromBits
+			if remToBits < toExtract {
+				toExtract = remToBits
+			}
+
+			// Add the next bits to nextByte, shifting the already
+			// added bits to the left.
+			nextByte = (nextByte << toExtract) | (b >> (8 - toExtract))
+
+			// Discard the bits we just extracted and get ready for
+			// next iteration.
+			b = b << toExtract
+			remFromBits -= toExtract
+			filledBits += toExtract
+
+			// If the nextByte is completely filled, we add it to
+			// our regrouped bytes and start on the next byte.
+			if filledBits == toBits {
+				regrouped = append(regrouped, nextByte)
+				filledBits = 0
+				nextByte = 0
+			}
+		}
+	}
+
+	// We pad any unfinished group if specified.
+	if pad && filledBits > 0 {
+		nextByte = nextByte << (toBits - filledBits)
+		regrouped = append(regrouped, nextByte)
+		filledBits = 0
+		nextByte = 0
+	}
+
+	// Any incomplete group must be <= 4 bits, and all zeroes.
+	if filledBits > 0 && (filledBits > 4 || nextByte != 0) {
+		return nil, fmt.Errorf("invalid incomplete group")
+	}
+
+	return regrouped, nil
+}
+
+// For more details on the checksum calculation, please refer to BIP 173.
+func bech32Checksum(hrp string, data []byte) []byte {
+	// Convert the bytes to list of integers, as this is needed for the
+	// checksum calculation.
+	integers := make([]int, len(data))
+	for i, b := range data {
+		integers[i] = int(b)
+	}
+	values := append(bech32HrpExpand(hrp), integers...)
+	values = append(values, []int{0, 0, 0, 0, 0, 0}...)
+	polymod := bech32Polymod(values) ^ 1
+	var res []byte
+	for i := 0; i < 6; i++ {
+		res = append(res, byte((polymod>>uint(5*(5-i)))&31))
+	}
+	return res
+}
+
+// For more details on the polymod calculation, please refer to BIP 173.
+func bech32Polymod(values []int) int {
+	chk := 1
+	for _, v := range values {
+		b := chk >> 25
+		chk = (chk&0x1ffffff)<<5 ^ v
+		for i := 0; i < 5; i++ {
+			if (b>>uint(i))&1 == 1 {
+				chk ^= gen[i]
+			}
+		}
+	}
+	return chk
+}
+
+// For more details on HRP expansion, please refer to BIP 173.
+func bech32HrpExpand(hrp string) []int {
+	v := make([]int, 0, len(hrp)*2+1)
+	for i := 0; i < len(hrp); i++ {
+		v = append(v, int(hrp[i]>>5))
+	}
+	v = append(v, 0)
+	for i := 0; i < len(hrp); i++ {
+		v = append(v, int(hrp[i]&31))
+	}
+	return v
+}
+
+// For more details on the checksum verification, please refer to BIP 173.
+func bech32VerifyChecksum(hrp string, data []byte) bool {
+	integers := make([]int, len(data))
+	for i, b := range data {
+		integers[i] = int(b)
+	}
+	concat := append(bech32HrpExpand(hrp), integers...)
+	return bech32Polymod(concat) == 1
+}

--- a/bech32/bech32_test.go
+++ b/bech32/bech32_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package bech32_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcutil/bech32"
+)
+
+func TestBech32(t *testing.T) {
+	tests := []struct {
+		str   string
+		valid bool
+	}{
+		{"A12UEL5L", true},
+		{"an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs", true},
+		{"abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw", true},
+		{"11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", true},
+		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", true},
+		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e2w", false},                                // invalid checksum
+		{"s lit1checkupstagehandshakeupstreamerranterredcaperredp8hs2p", false},                                // invalid character (space) in hrp
+		{"spl" + string(127) + "t1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false},              // invalid character (DEL) in hrp
+		{"split1cheo2y9e2w", false},                                                                            // invalid character (o) in data part
+		{"split1a2y9w", false},                                                                                 // too short data part
+		{"1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false},                                     // empty hrp
+		{"11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", false}, // too long
+	}
+
+	for _, test := range tests {
+		str := test.str
+		hrp, decoded, err := bech32.Decode(str)
+		if !test.valid {
+			// Invalid string decoding should result in error.
+			if err == nil {
+				t.Error("expected decoding to fail for "+
+					"invalid string %v", test.str)
+			}
+			continue
+		}
+
+		// Valid string decoding should result in no error.
+		if err != nil {
+			t.Errorf("expected string to be valid bech32: %v", err)
+		}
+
+		// Check that it encodes to the same string
+		encoded, err := bech32.Encode(hrp, decoded)
+		if err != nil {
+			t.Errorf("encoding failed: %v", err)
+		}
+
+		if encoded != strings.ToLower(str) {
+			t.Errorf("expected data to encode to %v, but got %v",
+				str, encoded)
+		}
+
+		// Flip a bit in the string an make sure it is caught.
+		pos := strings.LastIndexAny(str, "1")
+		flipped := str[:pos+1] + string((str[pos+1] ^ 1)) + str[pos+2:]
+		_, _, err = bech32.Decode(flipped)
+		if err == nil {
+			t.Error("expected decoding to fail")
+		}
+	}
+}

--- a/bech32/doc.go
+++ b/bech32/doc.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+/*
+Package bech32 provides a Go implementation of the bech32 format specified in
+BIP 173.
+
+Bech32 strings consist of a human-readable part (hrp), followed by the
+separator 1, then a checksummed data part encoded using the 32 characters
+"qpzry9x8gf2tvdw0s3jn54khce6mua7l".
+
+More info: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+*/
+package bech32

--- a/bech32/example_test.go
+++ b/bech32/example_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package bech32_test
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcutil/bech32"
+)
+
+// This example demonstrates how to decode a bech32 encoded string.
+func ExampleDecode() {
+	encoded := "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx"
+	hrp, decoded, err := bech32.Decode(encoded)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+
+	// Show the decoded data.
+	fmt.Println("Decoded human-readable part:", hrp)
+	fmt.Println("Decoded Data:", hex.EncodeToString(decoded))
+
+	// Output:
+	// Decoded human-readable part: bc
+	// Decoded Data: 010e140f070d1a001912060b0d081504140311021d030c1d03040f1814060e1e160e140f070d1a001912060b0d081504140311021d030c1d03040f1814060e1e16
+}
+
+// This example demonstrates how to encode data into a bech32 string.
+func ExampleEncode() {
+	data := []byte("Test data")
+	// Convert test data to base32:
+	conv, err := bech32.ConvertBits(data, 8, 5, true)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+	encoded, err := bech32.Encode("customHrp!11111q", conv)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+
+	// Show the encoded data.
+	fmt.Println("Encoded Data:", encoded)
+
+	// Output:
+	// Encoded Data: customHrp!11111q123jhxapqv3shgcgumastr
+}

--- a/internal_test.go
+++ b/internal_test.go
@@ -14,6 +14,7 @@ package btcutil
 import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil/base58"
+	"github.com/btcsuite/btcutil/bech32"
 	"golang.org/x/crypto/ripemd160"
 )
 
@@ -52,6 +53,30 @@ func TstAddressScriptHash(hash [ripemd160.Size]byte,
 	}
 }
 
+// TstAddressWitnessPubKeyHash creates an AddressWitnessPubKeyHash, initiating
+// the fields as given.
+func TstAddressWitnessPubKeyHash(version byte, program [20]byte,
+	hrp string) *AddressWitnessPubKeyHash {
+
+	return &AddressWitnessPubKeyHash{
+		hrp:            hrp,
+		witnessVersion: version,
+		witnessProgram: program,
+	}
+}
+
+// TstAddressWitnessScriptHash creates an AddressWitnessScriptHash, initiating
+// the fields as given.
+func TstAddressWitnessScriptHash(version byte, program [32]byte,
+	hrp string) *AddressWitnessScriptHash {
+
+	return &AddressWitnessScriptHash{
+		hrp:            hrp,
+		witnessVersion: version,
+		witnessProgram: program,
+	}
+}
+
 // TstAddressPubKey makes an AddressPubKey, setting the unexported fields with
 // the parameters.
 func TstAddressPubKey(serializedPubKey []byte, pubKeyFormat PubKeyFormat,
@@ -70,4 +95,20 @@ func TstAddressPubKey(serializedPubKey []byte, pubKeyFormat PubKeyFormat,
 func TstAddressSAddr(addr string) []byte {
 	decoded := base58.Decode(addr)
 	return decoded[1 : 1+ripemd160.Size]
+}
+
+// TstAddressSegwitSAddr returns the expected witness program bytes for
+// bech32 encoded P2WPKH and P2WSH bitcoin addresses.
+func TstAddressSegwitSAddr(addr string) []byte {
+	_, data, err := bech32.Decode(addr)
+	if err != nil {
+		return []byte{}
+	}
+
+	// First byte is version, rest is base 32 encoded data.
+	data, err = bech32.ConvertBits(data[1:], 5, 8, false)
+	if err != nil {
+		return []byte{}
+	}
+	return data
 }


### PR DESCRIPTION
This PR implements the Bech32 address format as specified in BIP 173: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki

Test are modeled after the Python reference implementation (https://github.com/sipa/bech32/blob/master/ref/python/tests.py) to ensure compatibility.