### PR TITLE
Fix some typos in docs

### DIFF
--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -30,8 +30,8 @@ const (
 	// to a master node.
 	RecommendedSeedLen = 32 // 256 bits
 
-	// HardenedKeyStart is the index at which a hardended key starts.  Each
-	// extended key has 2^31 normal child keys and 2^31 hardned child keys.
+	// HardenedKeyStart is the index at which a hardened key starts.  Each
+	// extended key has 2^31 normal child keys and 2^31 hardened child keys.
 	// Thus the range for normal child keys is [0, 2^31 - 1] and the range
 	// for hardened child keys is [2^31, 2^32 - 1].
 	HardenedKeyStart = 0x80000000 // 2^31
@@ -192,7 +192,7 @@ func (k *ExtendedKey) ParentFingerprint() uint32 {
 //
 // When the index is greater to or equal than the HardenedKeyStart constant, the
 // derived extended key will be a hardened extended key.  It is only possible to
-// derive a hardended extended key from a private extended key.  Consequently,
+// derive a hardened extended key from a private extended key.  Consequently,
 // this function will return ErrDeriveHardFromPublic if a hardened child
 // extended key is requested from a public extended key.
 //


### PR DESCRIPTION
This PR fixes 'hardended'/'hardned' to 'hardened' in the godocs.