### PR TITLE
Fix error in base58check test

### DIFF
--- a/base58/base58check_test.go
+++ b/base58/base58check_test.go
@@ -56,7 +56,7 @@ func TestBase58Check(t *testing.T) {
 	// bytes are missing).
 	testString := ""
 	for len := 0; len < 4; len++ {
-		// make a string of length `len`
+		testString = testString + "x"
 		_, _, err = base58.CheckDecode(testString)
 		if err != base58.ErrInvalidFormat {
 			t.Error("Checkdecode test failed, expected ErrInvalidFormat")


### PR DESCRIPTION
Currently the test checks the same empty string in every iteration of the loop.