### PR TITLE
bloom: Add encoding type to filter tests

### DIFF
--- a/bloom/filter_test.go
+++ b/bloom/filter_test.go
@@ -83,7 +83,7 @@ func TestFilterInsert(t *testing.T) {
 	}
 
 	got := bytes.NewBuffer(nil)
-	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion, wire.BaseEncoding)
 	if err != nil {
 		t.Errorf("TestFilterInsert BtcDecode failed: %v\n", err)
 		return
@@ -143,7 +143,7 @@ func TestFilterFPRange(t *testing.T) {
 		f := test.filter
 		f.AddHash(hash)
 		got := bytes.NewBuffer(nil)
-		err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+		err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion, wire.BaseEncoding)
 		if err != nil {
 			t.Errorf("BtcDecode unexpected error: %v\n", err)
 			continue
@@ -196,7 +196,7 @@ func TestFilterInsertWithTweak(t *testing.T) {
 		return
 	}
 	got := bytes.NewBuffer(nil)
-	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion, wire.BaseEncoding)
 	if err != nil {
 		t.Errorf("TestFilterInsertWithTweak BtcDecode failed: %v\n", err)
 		return
@@ -230,7 +230,7 @@ func TestFilterInsertKey(t *testing.T) {
 		return
 	}
 	got := bytes.NewBuffer(nil)
-	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion, wire.BaseEncoding)
 	if err != nil {
 		t.Errorf("TestFilterInsertWithTweak BtcDecode failed: %v\n", err)
 		return

--- a/bloom/merkleblock_test.go
+++ b/bloom/merkleblock_test.go
@@ -60,7 +60,7 @@ func TestMerkleBlock3(t *testing.T) {
 	}
 
 	got := bytes.NewBuffer(nil)
-	err = mBlock.BtcEncode(got, wire.ProtocolVersion)
+	err = mBlock.BtcEncode(got, wire.ProtocolVersion, wire.BaseEncoding)
 	if err != nil {
 		t.Errorf("TestMerkleBlock3 BtcEncode failed: %v", err)
 		return


### PR DESCRIPTION
The current version of btcd requires 3 parameters for the test to work,
this add wire.BaseEncoding parameter