### PR TITLE
gcs+gcs/builder: update BIP 158 generation code to match latest BIP changes

### DIFF
--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -371,46 +371,6 @@ func BuildBasicFilter(block *wire.MsgBlock) (*gcs.Filter, error) {
 	return b.Build()
 }
 
-// BuildExtFilter builds an extended GCS filter from a block. An extended
-// filter supplements a regular basic filter by include all the _witness_ data
-// found within a block. This includes all the data pushes within any signature
-// scripts as well as each element of an input's witness stack. Additionally,
-// the _hashes_ of each transaction are also inserted into the filter.
-func BuildExtFilter(block *wire.MsgBlock) (*gcs.Filter, error) {
-	blockHash := block.BlockHash()
-	b := WithKeyHash(&blockHash)
-
-	// If the filter had an issue with the specified key, then we force it
-	// to bubble up here by calling the Key() function.
-	_, err := b.Key()
-	if err != nil {
-		return nil, err
-	}
-
-	// In order to build an extended filter, we add the hash of each
-	// transaction as well as each piece of witness data included in both
-	// the sigScript and the witness stack of an input.
-	for i, tx := range block.Transactions {
-		// Skip the inputs for the coinbase transaction
-		if i != 0 {
-			// Next, for each input, we'll add the sigScript (if
-			// it's present), and also the witness stack (if it's
-			// present)
-			for _, txIn := range tx.TxIn {
-				if txIn.SignatureScript != nil {
-					b.AddScript(txIn.SignatureScript)
-				}
-
-				if len(txIn.Witness) != 0 {
-					b.AddWitness(txIn.Witness)
-				}
-			}
-		}
-	}
-
-	return b.Build()
-}
-
 // GetFilterHash returns the double-SHA256 of the filter.
 func GetFilterHash(filter *gcs.Filter) (chainhash.Hash, error) {
 	filterData, err := filter.NBytes()

--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -331,6 +331,10 @@ func BuildBasicFilter(block *wire.MsgBlock, prevOutScripts [][]byte) (*gcs.Filte
 		// For each output in a transaction, we'll add each of the
 		// individual data pushes within the script.
 		for _, txOut := range tx.TxOut {
+			if len(txOut.PkScript) == 0 {
+				continue
+			}
+
 			// In order to allow the filters to later be committed
 			// to within an OP_RETURN output, we ignore all
 			// OP_RETURNs to avoid a circular dependency.
@@ -346,6 +350,10 @@ func BuildBasicFilter(block *wire.MsgBlock, prevOutScripts [][]byte) (*gcs.Filte
 	// In the second pass, we'll also add all the prevOutScripts
 	// individually as elements.
 	for _, prevScript := range prevOutScripts {
+		if len(prevScript) == 0 {
+			continue
+		}
+
 		b.AddEntry(prevScript)
 	}
 

--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -331,6 +331,14 @@ func BuildBasicFilter(block *wire.MsgBlock, prevOutScripts [][]byte) (*gcs.Filte
 		// For each output in a transaction, we'll add each of the
 		// individual data pushes within the script.
 		for _, txOut := range tx.TxOut {
+			// In order to allow the filters to later be committed
+			// to within an OP_RETURN output, we ignore all
+			// OP_RETURNs to avoid a circular dependency.
+			if txOut.PkScript[0] == txscript.OP_RETURN &&
+				txscript.IsPushOnlyScript(txOut.PkScript[1:]) {
+				continue
+			}
+
 			b.AddEntry(txOut.PkScript)
 		}
 	}

--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -7,7 +7,6 @@ package builder
 
 import (
 	"crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"math"
 
@@ -65,17 +64,6 @@ func DeriveKey(keyHash *chainhash.Hash) [gcs.KeySize]byte {
 	var key [gcs.KeySize]byte
 	copy(key[:], keyHash.CloneBytes()[:])
 	return key
-}
-
-// OutPointToFilterEntry is a utility function that derives a filter entry from
-// a wire.OutPoint in a standardized way for use with both building and
-// querying filters.
-func OutPointToFilterEntry(outpoint wire.OutPoint) []byte {
-	// Size of the hash plus size of int32 index
-	data := make([]byte, chainhash.HashSize+4)
-	copy(data[:], outpoint.Hash.CloneBytes()[:])
-	binary.LittleEndian.PutUint32(data[chainhash.HashSize:], outpoint.Index)
-	return data
 }
 
 // Key retrieves the key with which the builder will build a filter. This is
@@ -186,17 +174,6 @@ func (b *GCSBuilder) AddEntries(data [][]byte) *GCSBuilder {
 		b.AddEntry(entry)
 	}
 	return b
-}
-
-// AddOutPoint adds a wire.OutPoint to the list of entries to be included in
-// the GCS filter when it's built.
-func (b *GCSBuilder) AddOutPoint(outpoint wire.OutPoint) *GCSBuilder {
-	// Do nothing if the builder's already errored out.
-	if b.err != nil {
-		return b
-	}
-
-	return b.AddEntry(OutPointToFilterEntry(outpoint))
 }
 
 // AddHash adds a chainhash.Hash to the list of entries to be included in the

--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -20,7 +20,8 @@ const DefaultP = 20
 
 // GCSBuilder is a utility class that makes building GCS filters convenient.
 type GCSBuilder struct {
-	p   uint8
+	p uint8
+
 	key [gcs.KeySize]byte
 
 	// data is a set of entries represented as strings. This is done to
@@ -242,8 +243,8 @@ func WithKeyP(key [gcs.KeySize]byte, p uint8) *GCSBuilder {
 	return WithKeyPN(key, p, 0)
 }
 
-// WithKey creates a GCSBuilder with specified key. Probability is set to
-// 20 (2^-20 collision probability). Estimated filter size is set to zero, which
+// WithKey creates a GCSBuilder with specified key. Probability is set to 19
+// (2^-19 collision probability). Estimated filter size is set to zero, which
 // means more reallocations are done when building the filter.
 func WithKey(key [gcs.KeySize]byte) *GCSBuilder {
 	return WithKeyPN(key, DefaultP, 0)
@@ -314,11 +315,6 @@ func BuildBasicFilter(block *wire.MsgBlock) (*gcs.Filter, error) {
 	// adding the outpoint data as well as the data pushes within the
 	// pkScript.
 	for i, tx := range block.Transactions {
-		// First we'll compute the bash of the transaction and add that
-		// directly to the filter.
-		txHash := tx.TxHash()
-		b.AddHash(&txHash)
-
 		// Skip the inputs for the coinbase transaction
 		if i != 0 {
 			// Each each txin, we'll add a serialized version of

--- a/gcs/builder/builder_test.go
+++ b/gcs/builder/builder_test.go
@@ -178,8 +178,8 @@ func TestUseBlockHash(t *testing.T) {
 	// Create a GCSBuilder with a known key and too-high P and ensure error
 	// works throughout all functions that use it.
 	b = builder.WithRandomKeyPM(33, 99).SetKeyFromHash(hash).SetKey(testKey)
-	b.SetP(30).AddEntry(hash.CloneBytes()).AddEntries(contents)
-	b.AddOutPoint(outPoint).AddHash(hash).AddScript(addrBytes)
+	b.SetP(30).AddEntry(hash.CloneBytes()).AddEntries(contents).
+		AddHash(hash).AddScript(addrBytes)
 	_, err = b.Key()
 	if err != gcs.ErrPTooBig {
 		t.Fatalf("No error on P too big!")
@@ -227,20 +227,6 @@ func BuilderTest(b *builder.GCSBuilder, hash *chainhash.Hash, p uint8,
 
 	// Add a hash, build a filter, and test matches
 	b.AddHash(hash)
-	f, err = b.Build()
-	if err != nil {
-		t.Fatalf("Filter build failed: %s", err.Error())
-	}
-	match, err = f.Match(key, hash.CloneBytes())
-	if err != nil {
-		t.Fatalf("Filter match failed: %s", err)
-	}
-	if !match {
-		t.Fatal("Filter didn't match when it should have!")
-	}
-
-	// Add a wire.OutPoint, build a filter, and test matches
-	b.AddOutPoint(outPoint)
 	f, err = b.Build()
 	if err != nil {
 		t.Fatalf("Filter build failed: %s", err.Error())

--- a/gcs/builder/builder_test.go
+++ b/gcs/builder/builder_test.go
@@ -105,7 +105,7 @@ func TestUseBlockHash(t *testing.T) {
 	BuilderTest(b, hash, builder.DefaultP, outPoint, addrBytes, witness, t)
 
 	// Create a GCSBuilder with a key hash and non-default P and test it.
-	b = builder.WithKeyHashP(hash, 30)
+	b = builder.WithKeyHashPM(hash, 30, 90)
 	BuilderTest(b, hash, 30, outPoint, addrBytes, witness, t)
 
 	// Create a GCSBuilder with a random key, set the key from a hash
@@ -135,7 +135,7 @@ func TestUseBlockHash(t *testing.T) {
 	BuilderTest(b, hash, builder.DefaultP, outPoint, addrBytes, witness, t)
 
 	// Create a GCSBuilder with a random key and non-default P and test it.
-	b = builder.WithRandomKeyP(30)
+	b = builder.WithRandomKeyPM(30, 90)
 	key2, err := b.Key()
 	if err != nil {
 		t.Fatalf("Builder instantiation with random key failed: %s",
@@ -162,7 +162,7 @@ func TestUseBlockHash(t *testing.T) {
 	BuilderTest(b, hash, builder.DefaultP, outPoint, addrBytes, witness, t)
 
 	// Create a GCSBuilder with a known key and non-default P and test it.
-	b = builder.WithKeyP(testKey, 30)
+	b = builder.WithKeyPM(testKey, 30, 90)
 	key, err = b.Key()
 	if err != nil {
 		t.Fatalf("Builder instantiation with known key failed: %s",
@@ -177,7 +177,7 @@ func TestUseBlockHash(t *testing.T) {
 
 	// Create a GCSBuilder with a known key and too-high P and ensure error
 	// works throughout all functions that use it.
-	b = builder.WithRandomKeyP(33).SetKeyFromHash(hash).SetKey(testKey)
+	b = builder.WithRandomKeyPM(33, 99).SetKeyFromHash(hash).SetKey(testKey)
 	b.SetP(30).AddEntry(hash.CloneBytes()).AddEntries(contents)
 	b.AddOutPoint(outPoint).AddHash(hash).AddScript(addrBytes)
 	_, err = b.Key()

--- a/gcs/builder/builder_test.go
+++ b/gcs/builder/builder_test.go
@@ -254,17 +254,12 @@ func BuilderTest(b *builder.GCSBuilder, hash *chainhash.Hash, p uint8,
 	}
 
 	// Add a script, build a filter, and test matches
-	b.AddScript(addrBytes)
+	b.AddEntry(addrBytes)
 	f, err = b.Build()
 	if err != nil {
 		t.Fatalf("Filter build failed: %s", err.Error())
 	}
-	pushedData, err := txscript.PushedData(addrBytes)
-	if err != nil {
-		t.Fatalf("Couldn't extract pushed data from addrBytes script: %s",
-			err.Error())
-	}
-	match, err = f.MatchAny(key, pushedData)
+	match, err = f.MatchAny(key, [][]byte{addrBytes})
 	if err != nil {
 		t.Fatalf("Filter match any failed: %s", err)
 	}

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -175,7 +175,6 @@ func BuildGCSFilter(P uint8, M uint64, key [KeySize]byte, data [][]byte) (*Filte
 // FromBytes deserializes a GCS filter from a known N, P, and serialized filter
 // as returned by Bytes().
 func FromBytes(N uint32, P uint8, M uint64, d []byte) (*Filter, error) {
-
 	// Basic sanity check.
 	if P > 32 {
 		return nil, ErrPTooBig
@@ -287,7 +286,6 @@ func (f *Filter) N() uint32 {
 // Match checks whether a []byte value is likely (within collision probability)
 // to be a member of the set represented by the filter.
 func (f *Filter) Match(key [KeySize]byte, data []byte) (bool, error) {
-
 	// Create a filter bitstream.
 	filterData, err := f.Bytes()
 	if err != nil {
@@ -335,7 +333,6 @@ func (f *Filter) Match(key [KeySize]byte, data []byte) (bool, error) {
 // probability) to be a member of the set represented by the filter faster than
 // calling Match() for each value individually.
 func (f *Filter) MatchAny(key [KeySize]byte, data [][]byte) (bool, error) {
-
 	// Basic sanity check.
 	if len(data) == 0 {
 		return false, nil

--- a/gcs/gcs_test.go
+++ b/gcs/gcs_test.go
@@ -18,8 +18,11 @@ var (
 	// No need to allocate an err variable in every test
 	err error
 
-	// Collision probability for the tests (1/2**20)
-	P = uint8(20)
+	// Collision probability for the tests (1/2**19)
+	P = uint8(19)
+
+	// Modulus value for the tests.
+	M uint64 = 784931
 
 	// Filters are conserved between tests but we must define with an
 	// interface which functions we're testing because the gcsFilter type
@@ -79,7 +82,7 @@ func TestGCSFilterBuild(t *testing.T) {
 	for i := 0; i < gcs.KeySize; i += 4 {
 		binary.BigEndian.PutUint32(key[i:], rand.Uint32())
 	}
-	filter, err = gcs.BuildGCSFilter(P, key, contents)
+	filter, err = gcs.BuildGCSFilter(P, M, key, contents)
 	if err != nil {
 		t.Fatalf("Filter build failed: %s", err.Error())
 	}
@@ -91,7 +94,7 @@ func TestGCSFilterCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Filter Bytes() failed: %v", err)
 	}
-	filter2, err = gcs.FromBytes(filter.N(), P, serialized2)
+	filter2, err = gcs.FromBytes(filter.N(), P, M, serialized2)
 	if err != nil {
 		t.Fatalf("Filter copy failed: %s", err.Error())
 	}
@@ -99,23 +102,7 @@ func TestGCSFilterCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Filter NBytes() failed: %v", err)
 	}
-	filter3, err = gcs.FromNBytes(filter.P(), serialized3)
-	if err != nil {
-		t.Fatalf("Filter copy failed: %s", err.Error())
-	}
-	serialized4, err := filter.PBytes()
-	if err != nil {
-		t.Fatalf("Filter PBytes() failed: %v", err)
-	}
-	filter4, err = gcs.FromPBytes(filter.N(), serialized4)
-	if err != nil {
-		t.Fatalf("Filter copy failed: %s", err.Error())
-	}
-	serialized5, err := filter.NPBytes()
-	if err != nil {
-		t.Fatalf("Filter NPBytes() failed: %v", err)
-	}
-	filter5, err = gcs.FromNPBytes(serialized5)
+	filter3, err = gcs.FromNBytes(filter.P(), M, serialized3)
 	if err != nil {
 		t.Fatalf("Filter copy failed: %s", err.Error())
 	}
@@ -136,22 +123,10 @@ func TestGCSFilterMetadata(t *testing.T) {
 	if filter.P() != filter3.P() {
 		t.Fatal("P doesn't match between copied filters")
 	}
-	if filter.P() != filter4.P() {
-		t.Fatal("P doesn't match between copied filters")
-	}
-	if filter.P() != filter5.P() {
-		t.Fatal("P doesn't match between copied filters")
-	}
 	if filter.N() != filter2.N() {
 		t.Fatal("N doesn't match between copied filters")
 	}
 	if filter.N() != filter3.N() {
-		t.Fatal("N doesn't match between copied filters")
-	}
-	if filter.N() != filter4.N() {
-		t.Fatal("N doesn't match between copied filters")
-	}
-	if filter.N() != filter5.N() {
 		t.Fatal("N doesn't match between copied filters")
 	}
 	serialized, err := filter.Bytes()
@@ -177,13 +152,6 @@ func TestGCSFilterMetadata(t *testing.T) {
 		t.Fatalf("Filter Bytes() failed: %v", err)
 	}
 	if !bytes.Equal(serialized, serialized4) {
-		t.Fatal("Bytes don't match between copied filters")
-	}
-	serialized5, err := filter5.Bytes()
-	if err != nil {
-		t.Fatalf("Filter Bytes() failed: %v", err)
-	}
-	if !bytes.Equal(serialized, serialized5) {
 		t.Fatal("Bytes don't match between copied filters")
 	}
 }

--- a/gcs/gcsbench_test.go
+++ b/gcs/gcsbench_test.go
@@ -10,7 +10,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/roasbeef/btcutil/gcs"
+	"github.com/btcsuite/btcutil/gcs"
 )
 
 func genRandFilterElements(numElements uint) ([][]byte, error) {
@@ -46,8 +46,9 @@ func BenchmarkGCSFilterBuild50000(b *testing.B) {
 
 	var localFilter *gcs.Filter
 	for i := 0; i < b.N; i++ {
-		localFilter, err = gcs.BuildGCSFilter(P, key,
-			randFilterElems)
+		localFilter, err = gcs.BuildGCSFilter(
+			P, key, randFilterElems,
+		)
 		if err != nil {
 			b.Fatalf("unable to generate filter: %v", err)
 		}

--- a/gcs/gcsbench_test.go
+++ b/gcs/gcsbench_test.go
@@ -38,16 +38,18 @@ func BenchmarkGCSFilterBuild50000(b *testing.B) {
 	for i := 0; i < gcs.KeySize; i += 4 {
 		binary.BigEndian.PutUint32(testKey[i:], rand.Uint32())
 	}
+
 	randFilterElems, genErr := genRandFilterElements(50000)
 	if err != nil {
 		b.Fatalf("unable to generate random item: %v", genErr)
 	}
+
 	b.StartTimer()
 
 	var localFilter *gcs.Filter
 	for i := 0; i < b.N; i++ {
 		localFilter, err = gcs.BuildGCSFilter(
-			P, key, randFilterElems,
+			P, M, key, randFilterElems,
 		)
 		if err != nil {
 			b.Fatalf("unable to generate filter: %v", err)
@@ -63,16 +65,19 @@ func BenchmarkGCSFilterBuild100000(b *testing.B) {
 	for i := 0; i < gcs.KeySize; i += 4 {
 		binary.BigEndian.PutUint32(testKey[i:], rand.Uint32())
 	}
+
 	randFilterElems, genErr := genRandFilterElements(100000)
 	if err != nil {
 		b.Fatalf("unable to generate random item: %v", genErr)
 	}
+
 	b.StartTimer()
 
 	var localFilter *gcs.Filter
 	for i := 0; i < b.N; i++ {
-		localFilter, err = gcs.BuildGCSFilter(P, key,
-			randFilterElems)
+		localFilter, err = gcs.BuildGCSFilter(
+			P, M, key, randFilterElems,
+		)
 		if err != nil {
 			b.Fatalf("unable to generate filter: %v", err)
 		}
@@ -87,7 +92,7 @@ var (
 // BenchmarkGCSFilterMatch benchmarks querying a filter for a single value.
 func BenchmarkGCSFilterMatch(b *testing.B) {
 	b.StopTimer()
-	filter, err := gcs.BuildGCSFilter(P, key, contents)
+	filter, err := gcs.BuildGCSFilter(P, M, key, contents)
 	if err != nil {
 		b.Fatalf("Failed to build filter")
 	}
@@ -114,7 +119,7 @@ func BenchmarkGCSFilterMatch(b *testing.B) {
 // values.
 func BenchmarkGCSFilterMatchAny(b *testing.B) {
 	b.StopTimer()
-	filter, err := gcs.BuildGCSFilter(P, key, contents)
+	filter, err := gcs.BuildGCSFilter(P, M, key, contents)
 	if err != nil {
 		b.Fatalf("Failed to build filter")
 	}


### PR DESCRIPTION
In this PR, we update the BIP 158 generation code to match the latest BIP changes. The notable changes are:
  * regular filter no longer includes the txid
  * we now use distinct `M` and `N` values rather than setting `P` as it results in a small improvement
  * the regular filter now uses the prev output scripts rather than the outpoint as it achieves better compression 
  * there's no longer an extended filter
  * when indexing scripts, we skip all `OP_RETURN` outputs