### PR TITLE
gcs/builder: remove the AddScript method as it's no longer used

### DIFF
--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -187,24 +187,6 @@ func (b *GCSBuilder) AddHash(hash *chainhash.Hash) *GCSBuilder {
 	return b.AddEntry(hash.CloneBytes())
 }
 
-// AddScript adds all the data pushed in the script serialized as the passed
-// []byte to the list of entries to be included in the GCS filter when it's
-// built.
-func (b *GCSBuilder) AddScript(script []byte) *GCSBuilder {
-	// Do nothing if the builder's already errored out.
-	if b.err != nil {
-		return b
-	}
-
-	// Ignore errors and add pushed data, if any
-	data, _ := txscript.PushedData(script)
-	if len(data) == 0 {
-		return b
-	}
-
-	return b.AddEntries(data)
-}
-
 // AddWitness adds each item of the passed filter stack to the filter, and then
 // adds each item as a script.
 func (b *GCSBuilder) AddWitness(witness wire.TxWitness) *GCSBuilder {

--- a/gcs/builder/builder_test.go
+++ b/gcs/builder/builder_test.go
@@ -179,7 +179,7 @@ func TestUseBlockHash(t *testing.T) {
 	// works throughout all functions that use it.
 	b = builder.WithRandomKeyPM(33, 99).SetKeyFromHash(hash).SetKey(testKey)
 	b.SetP(30).AddEntry(hash.CloneBytes()).AddEntries(contents).
-		AddHash(hash).AddScript(addrBytes)
+		AddHash(hash).AddEntry(addrBytes)
 	_, err = b.Key()
 	if err != gcs.ErrPTooBig {
 		t.Fatalf("No error on P too big!")
@@ -270,7 +270,7 @@ func BuilderTest(b *builder.GCSBuilder, hash *chainhash.Hash, p uint8,
 
 	// Check that adding duplicate items does not increase filter size.
 	originalSize := f.N()
-	b.AddScript(addrBytes)
+	b.AddEntry(addrBytes)
 	b.AddWitness(witness)
 	f, err = b.Build()
 	if err != nil {


### PR DESCRIPTION
In this commit, we remove the AddScript method as it's no longer used,
and AddEntry should be used in place for adding pkScripts to the
filters.