### PR TITLE
hdkeychain: fix trivial typo

### DIFF
--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -517,8 +517,8 @@ tests:
 	}
 }
 
-// TestGenenerateSeed ensures the GenerateSeed function works as intended.
-func TestGenenerateSeed(t *testing.T) {
+// TestGenerateSeed ensures the GenerateSeed function works as intended.
+func TestGenerateSeed(t *testing.T) {
 	wantErr := errors.New("seed length must be between 128 and 512 bits")
 
 	tests := []struct {


### PR DESCRIPTION
This PR fixes typo in `hdkeychain/extendedkey_test.go`