### PR TITLE
use defaultnet params instead of btc chaincfg for decode address

### DIFF
--- a/address.go
+++ b/address.go
@@ -188,8 +188,8 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 	}
 	switch len(decoded) {
 	case ripemd160.Size: // P2PKH or P2SH
-		isP2PKH := chaincfg.IsPubKeyHashAddrID(netID)
-		isP2SH := chaincfg.IsScriptHashAddrID(netID)
+		isP2PKH := netID == defaultNet.PubKeyHashAddrID
+		isP2SH := netID == defaultNet.ScriptHashAddrID
 		switch hash160 := decoded; {
 		case isP2PKH && isP2SH:
 			return nil, ErrAddressCollision

--- a/address_test.go
+++ b/address_test.go
@@ -17,6 +17,26 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
+type CustomParamStruct struct {
+	PubKeyHashAddrID byte
+	ScriptHashAddrID byte
+}
+
+var CustomParams = CustomParamStruct{
+	PubKeyHashAddrID: 0x30, // starts with L
+	ScriptHashAddrID: 0x32, // starts with M
+}
+
+// We use this function to be able to test functionality in DecodeAddress for
+// defaultNet addresses
+func applyCustomParams(params chaincfg.Params, customParams CustomParamStruct) chaincfg.Params {
+	params.PubKeyHashAddrID = customParams.PubKeyHashAddrID
+	params.ScriptHashAddrID = customParams.ScriptHashAddrID
+	return params
+}
+
+var customParams = applyCustomParams(chaincfg.MainNetParams, CustomParams)
+
 func TestAddresses(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -63,6 +83,24 @@ func TestAddresses(t *testing.T) {
 				return btcutil.NewAddressPubKeyHash(pkHash, &chaincfg.MainNetParams)
 			},
 			net: &chaincfg.MainNetParams,
+		},
+		{
+			name:    "litecoin mainnet p2pkh",
+			addr:    "LM2WMpR1Rp6j3Sa59cMXMs1SPzj9eXpGc1",
+			encoded: "LM2WMpR1Rp6j3Sa59cMXMs1SPzj9eXpGc1",
+			valid:   true,
+			result: btcutil.TstAddressPubKeyHash(
+				[ripemd160.Size]byte{
+					0x13, 0xc6, 0x0d, 0x8e, 0x68, 0xd7, 0x34, 0x9f, 0x5b, 0x4c,
+					0xa3, 0x62, 0xc3, 0x95, 0x4b, 0x15, 0x04, 0x50, 0x61, 0xb1},
+				CustomParams.PubKeyHashAddrID),
+			f: func() (btcutil.Address, error) {
+				pkHash := []byte{
+					0x13, 0xc6, 0x0d, 0x8e, 0x68, 0xd7, 0x34, 0x9f, 0x5b, 0x4c,
+					0xa3, 0x62, 0xc3, 0x95, 0x4b, 0x15, 0x04, 0x50, 0x61, 0xb1}
+				return btcutil.NewAddressPubKeyHash(pkHash, &customParams)
+			},
+			net: &customParams,
 		},
 		{
 			name:    "testnet p2pkh",
@@ -144,6 +182,24 @@ func TestAddresses(t *testing.T) {
 				return btcutil.NewAddressScriptHash(script, &chaincfg.MainNetParams)
 			},
 			net: &chaincfg.MainNetParams,
+		},
+		{
+			name:    "litecoin mainnet P2SH ",
+			addr:    "MVcg9uEvtWuP5N6V48EHfEtbz48qR8TKZ9",
+			encoded: "MVcg9uEvtWuP5N6V48EHfEtbz48qR8TKZ9",
+			valid:   true,
+			result: btcutil.TstAddressScriptHash(
+				[ripemd160.Size]byte{
+					0xee, 0x34, 0xac, 0x67, 0x6b, 0xda, 0xf6, 0xe3, 0x70, 0xc8,
+					0xc8, 0x20, 0xb9, 0x48, 0xed, 0xfa, 0xd3, 0xa8, 0x73, 0xd8},
+				CustomParams.ScriptHashAddrID),
+			f: func() (btcutil.Address, error) {
+				pkHash := []byte{
+					0xEE, 0x34, 0xAC, 0x67, 0x6B, 0xDA, 0xF6, 0xE3, 0x70, 0xC8,
+					0xC8, 0x20, 0xB9, 0x48, 0xED, 0xFA, 0xD3, 0xA8, 0x73, 0xD8}
+				return btcutil.NewAddressScriptHashFromHash(pkHash, &customParams)
+			},
+			net: &customParams,
 		},
 		{
 			// Taken from transactions:


### PR DESCRIPTION
This PR fixes a bug where BTCs default chain params from `chaincfg` are being used instead of the `defaultNet` when trying to decode a wallet address in `DecodeAddress`.

A user may want to override the default values of `chaincfg` by passing in a different set of `defaultNet` params, however `DecodeAddress` will currently throw `ErrUnknownAddressType` if the P2PKH or P2SH values do not match the default hardcoded values found in `btcd/chaincfg`.

An additional benefit to this change is that P2PKH and P2SH values are scoped to the network instead of checking ALL values that were configured with `chaincfg`