### PR TITLE
fix leading zero

### DIFF
--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -295,6 +295,10 @@ func (k *ExtendedKey) Child(i uint32) (*ExtendedKey, error) {
 		ilNum.Add(ilNum, keyNum)
 		ilNum.Mod(ilNum, btcec.S256().N)
 		childKey = ilNum.Bytes()
+		if len(childKey) < 32 {
+			extra := make([]byte, 32-len(childKey))
+			childKey = append(extra, childKey...)
+		}
 		isPrivate = true
 	} else {
 		// Case #3.


### PR DESCRIPTION
it was a mistake on the m/44H/60H/0H path
For example, mnemonic := "real town addict extend shoot name disagree vital turn live can tip"
got c64f0b3e510d03adef3f057d1814bdc8a7f904caafa6928550fc10670dcff031
wanted c29cd818232f40614691a58c9afcbd5518b539cb135d73b1d9e26d5f5f5dcbbe (https://iancoleman.io/bip39/)
```
        // Generate a Bip32 HD wallet for the mnemonic and a user supplied password
	seed := bip39.NewSeed(mnemonic, "")

	// Generate a new master node using the seed.
	masterKey, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
	if err != nil {
		return nil, nil, err
	}

	// This gives the path: m/44H
	acc44H, err := masterKey.Child(hdkeychain.HardenedKeyStart + 44)
	if err != nil {
		return nil, nil, err
	}

	// This gives the path: m/44H/60H
	acc44H60H, err := acc44H.Child(hdkeychain.HardenedKeyStart + 60)
	if err != nil {
		return nil, nil, err
	}

	// This gives the path: m/44H/60H/0H
	acc44H60H0H, err := acc44H60H.Child(hdkeychain.HardenedKeyStart + 0)
	if err != nil {
		return nil, nil, err
	}

	// This gives the path: m/44H/60H/0H/0
	acc44H60H0H0, err := acc44H60H0H.Child(0)
	if err != nil {
		return nil, nil, err
	}

	// This gives the path: m/44H/60H/0H/0/0
	acc44H60H0H00, err := acc44H60H0H0.Child(0)
	if err != nil {
		return nil, nil, err
	}

	btcecPrivKey, err := acc44H60H0H00.ECPrivKey()
	if err != nil {
		return nil, nil, err
	}

	privateKey := btcecPrivKey.ToECDSA()
```