### PR TITLE
psbt: fix two deserialization bugs

### DIFF
--- a/psbt/partial_input.go
+++ b/psbt/partial_input.go
@@ -141,6 +141,12 @@ func (pi *PInput) deserialize(r io.Reader) error {
 				return ErrInvalidKeydata
 			}
 
+			// Bounds check on value here since the sighash type must be a
+			// 32-bit unsigned integer.
+			if len(value) != 4 {
+				return ErrInvalidKeydata
+			}
+
 			shtype := txscript.SigHashType(
 				binary.LittleEndian.Uint32(value),
 			)

--- a/psbt/psbt.go
+++ b/psbt/psbt.go
@@ -33,6 +33,10 @@ var (
 //less than 4M.
 const MaxPsbtValueLength = 4000000
 
+// MaxPsbtKeyLength is the length of the largest key that we'll successfully
+// deserialize from the wire. Anything more will return ErrInvalidKeydata.
+const MaxPsbtKeyLength = 10000
+
 var (
 
 	// ErrInvalidPsbtFormat is a generic error for any situation in which a

--- a/psbt/utils.go
+++ b/psbt/utils.go
@@ -237,6 +237,11 @@ func getKey(r io.Reader) (int, []byte, error) {
 		return -1, nil, nil
 	}
 
+	// Check that we don't attempt to decode a dangerously large key.
+	if count > MaxPsbtKeyLength {
+		return -1, nil, ErrInvalidKeydata
+	}
+
 	// Next, we ready out the designated number of bytes, which may include
 	// a type, key, and optional data.
 	keyTypeAndData := make([]byte, count)


### PR DESCRIPTION
Fuzzer found two panics:

first one:
```
panic: runtime error: index out of range [3] with length 1

goroutine 1 [running]:
encoding/binary.littleEndian.Uint32(...)
	/usr/local/Cellar/go/1.13/libexec/src/encoding/binary/binary.go:63
github.com/btcsuite/btcutil/psbt.(*PInput).deserialize(0xc0004c3db0, 0x12f3760, 0xc00009e2d0, 0xc0004c3df0, 0x1062de6)
	/Users/nsa/go/src/github.com/btcsuite/btcutil/psbt/partial_input.go:153 +0x1be6
github.com/btcsuite/btcutil/psbt.Fuzz_partial_input_serialization(0x5010000, 0x4, 0x4, 0x3)
	/Users/nsa/go/src/github.com/btcsuite/btcutil/psbt/partial_input_serialization.go:13 +0xf2
```

second one:
```
panic: runtime error: makeslice: len out of range

goroutine 1 [running]:
github.com/btcsuite/btcutil/psbt.getKey(0x12f3760, 0xc0000988a0, 0x8, 0x149d438, 0x203000, 0x203000, 0xaa, 0x13f0ae0)
	/Users/nsa/go/src/github.com/btcsuite/btcutil/psbt/utils.go:242 +0xf8
github.com/btcsuite/btcutil/psbt.(*PInput).deserialize(0xc000453db0, 0x12f3760, 0xc0000988a0, 0xc000453df0, 0x1062de6)
	/Users/nsa/go/src/github.com/btcsuite/btcutil/psbt/partial_input.go:80 +0x80
github.com/btcsuite/btcutil/psbt.Fuzz_partial_input_serialization(0x4710000, 0x9, 0x9, 0x4)
	/Users/nsa/go/src/github.com/btcsuite/btcutil/psbt/partial_input_serialization.go:13 +0xf2
```