### PR TITLE
psbt: restore compatibility with wallets that patch CVE-2020-14199

### DIFF
--- a/psbt/partial_input.go
+++ b/psbt/partial_input.go
@@ -49,19 +49,13 @@ func NewPsbtInput(nonWitnessUtxo *wire.MsgTx,
 }
 
 // IsSane returns true only if there are no conflicting values in the Psbt
-// PInput. It checks that witness and non-witness utxo entries do not both
-// exist, and that witnessScript entries are only added to witness inputs.
+// PInput. For segwit v0 no checks are currently implemented.
 func (pi *PInput) IsSane() bool {
 
-	if pi.NonWitnessUtxo != nil && pi.WitnessUtxo != nil {
-		return false
-	}
-	if pi.WitnessUtxo == nil && pi.WitnessScript != nil {
-		return false
-	}
-	if pi.WitnessUtxo == nil && pi.FinalScriptWitness != nil {
-		return false
-	}
+	// TODO(guggero): Implement sanity checks for segwit v1. For segwit v0
+	// it is unsafe to only rely on the witness UTXO so we don't check that
+	// only one is set anymore.
+	// See https://github.com/bitcoin/bitcoin/pull/19215.
 
 	return true
 }

--- a/psbt/psbt_test.go
+++ b/psbt/psbt_test.go
@@ -161,6 +161,9 @@ func TestReadInvalidPsbt(t *testing.T) {
 }
 
 func TestSanityCheck(t *testing.T) {
+	// TODO(guggero): Remove when checks for segwit v1 are implemented.
+	t.Skip("Skipping PSBT sanity checks for segwit v0.")
+
 	// Test strategy:
 	// 1. Create an invalid PSBT from a serialization
 	// Then ensure that the sanity check fails.

--- a/psbt/signer.go
+++ b/psbt/signer.go
@@ -142,8 +142,11 @@ func nonWitnessToWitness(p *Packet, inIndex int) error {
 	outIndex := p.UnsignedTx.TxIn[inIndex].PreviousOutPoint.Index
 	txout := p.Inputs[inIndex].NonWitnessUtxo.TxOut[outIndex]
 
-	// Remove the non-witness first, else sanity check will not pass:
-	p.Inputs[inIndex].NonWitnessUtxo = nil
+	// TODO(guggero): For segwit v1, we'll want to remove the NonWitnessUtxo
+	// from the packet. For segwit v0 it is unsafe to only rely on the
+	// witness UTXO. See https://github.com/bitcoin/bitcoin/pull/19215.
+	// p.Inputs[inIndex].NonWitnessUtxo = nil
+
 	u := Updater{
 		Upsbt: p,
 	}


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/4400.

Wallets that include the fix for the CVE-2020-14199 vulnerability always include the full non-witness UTXO even if the output being spent is a witness output.
To restore compatibility with those wallets, [Bitcoin Core removed the sanity checks on partial inputs](https://github.com/bitcoin/bitcoin/pull/19215).
This PR does the same for the `btcutil/psbt` library.