### PR TITLE
Drop string construction from integers

### DIFF
--- a/address.go
+++ b/address.go
@@ -23,7 +23,7 @@ import (
 type UnsupportedWitnessVerError byte
 
 func (e UnsupportedWitnessVerError) Error() string {
-	return "unsupported witness version: " + string(e)
+	return fmt.Sprintf("unsupported witness version: %#x", e)
 }
 
 // UnsupportedWitnessProgLenError describes an error where a segwit address
@@ -31,7 +31,7 @@ func (e UnsupportedWitnessVerError) Error() string {
 type UnsupportedWitnessProgLenError int
 
 func (e UnsupportedWitnessProgLenError) Error() string {
-	return "unsupported witness program length: " + string(e)
+	return fmt.Sprintf("unsupported witness program length: %d", e)
 }
 
 var (

--- a/bech32/bech32_test.go
+++ b/bech32/bech32_test.go
@@ -23,7 +23,7 @@ func TestBech32(t *testing.T) {
 		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", true},
 		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e2w", false},                                // invalid checksum
 		{"s lit1checkupstagehandshakeupstreamerranterredcaperredp8hs2p", false},                                // invalid character (space) in hrp
-		{"spl" + string(127) + "t1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false},              // invalid character (DEL) in hrp
+		{"spl\x7Ft1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false},              // invalid character (DEL) in hrp
 		{"split1cheo2y9e2w", false},                                                                            // invalid character (o) in data part
 		{"split1a2y9w", false},                                                                                 // too short data part
 		{"1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false},                                     // empty hrp


### PR DESCRIPTION
Go no longer allows it. The FIX is a good demonstration on the why. ;-)