### PR TITLE
fix go 1.15 compatibility

### DIFF
--- a/address.go
+++ b/address.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -31,7 +32,7 @@ func (e UnsupportedWitnessVerError) Error() string {
 type UnsupportedWitnessProgLenError int
 
 func (e UnsupportedWitnessProgLenError) Error() string {
-	return "unsupported witness program length: " + string(e)
+	return "unsupported witness program length: " + strconv.Itoa(int(e))
 }
 
 var (


### PR DESCRIPTION
This also fixes a formatting bug in `UnsupportedWitnessProgLenError`'s error message.