### PR TITLE
Add helper functions to generate (nested) segwit addresses from extended key

### DIFF
--- a/hdkeychain/doc.go
+++ b/hdkeychain/doc.go
@@ -24,8 +24,8 @@ with the IsPrivate function.
 Transaction Signing Keys and Payment Addresses
 
 In order to create and sign transactions, or provide others with addresses to
-send funds to, the underlying key and address material must be accessible.  This
-package provides the ECPubKey, ECPrivKey, and Address functions for this
+send funds to, the underlying key and address material must be accessible. This
+package provides the ECPubKey, ECPrivKey, and various Address functions for this
 purpose.
 
 The Master Node

--- a/hdkeychain/example_test.go
+++ b/hdkeychain/example_test.go
@@ -116,24 +116,24 @@ func Example_defaultWalletLayout() {
 		return
 	}
 
-	// Get and show the address associated with the extended keys for the
+	// Get and show the P2PKH address associated with the extended keys for the
 	// main bitcoin	network.
-	acct0ExtAddr, err := acct0Ext10.Address(&chaincfg.MainNetParams)
+	acct0ExtAddr, err := acct0Ext10.AddressP2PKH(&chaincfg.MainNetParams)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	acct0IntAddr, err := acct0Int0.Address(&chaincfg.MainNetParams)
+	acct0IntAddr, err := acct0Int0.AddressP2PKH(&chaincfg.MainNetParams)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	fmt.Println("Account 0 External Address 10:", acct0ExtAddr)
-	fmt.Println("Account 0 Internal Address 0:", acct0IntAddr)
+	fmt.Println("Account 0 External P2PKH Address 10:", acct0ExtAddr)
+	fmt.Println("Account 0 Internal P2PKH Address 0:", acct0IntAddr)
 
 	// Output:
-	// Account 0 External Address 10: 1HVccubUT8iKTapMJ5AnNA4sLRN27xzQ4F
-	// Account 0 Internal Address 0: 1J5rebbkQaunJTUoNVREDbeB49DqMNFFXk
+	// Account 0 External P2PKH Address 10: 1HVccubUT8iKTapMJ5AnNA4sLRN27xzQ4F
+	// Account 0 Internal P2PKH Address 0: 1J5rebbkQaunJTUoNVREDbeB49DqMNFFXk
 }
 
 // This example demonstrates the audits use case in BIP0032.

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -504,9 +504,9 @@ func (k *ExtendedKey) ECPrivKey() (*btcec.PrivateKey, error) {
 	return privKey, nil
 }
 
-// Address converts the extended key to a standard bitcoin pay-to-pubkey-hash
+// AddressP2PKH converts the extended key to a standard bitcoin pay-to-pubkey-hash
 // address for the passed network.
-func (k *ExtendedKey) Address(net *chaincfg.Params) (*btcutil.AddressPubKeyHash, error) {
+func (k *ExtendedKey) AddressP2PKH(net *chaincfg.Params) (*btcutil.AddressPubKeyHash, error) {
 	pkHash := btcutil.Hash160(k.pubKeyBytes())
 	return btcutil.NewAddressPubKeyHash(pkHash, net)
 }

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -521,6 +521,35 @@ func (k *ExtendedKey) AddressP2PKH(net *chaincfg.Params) (*btcutil.AddressPubKey
 	return btcutil.NewAddressPubKeyHash(pkHash, net)
 }
 
+// AddressNP2WPKH converts the extended key to a bitcoin pay-to-witness-public-key-hash
+// nested in a pay-to-script-hash address for the passed network.
+func (k *ExtendedKey) AddressNP2WPKH(net *chaincfg.Params) (*btcutil.AddressScriptHash, error) {
+	pkHash := btcutil.Hash160(k.pubKeyBytes())
+
+	// The simplest way: hard-code the witnessProgram for version 0:
+	// witnessVersion := []byte{0x00}
+	// witnessHash := append([]byte{0x14}, pkHash...)
+	// witnessProgram := append(witnessVersion, witnessHash...)
+
+	// The generic way: let NewAddressWitnessPubKeyHash define the version, etc.:
+	P2WPKH, err := btcutil.NewAddressWitnessPubKeyHash(pkHash, net)
+	if err != nil {
+		return nil, err
+	}
+	witnessVersion := []byte{P2WPKH.WitnessVersion()}
+	witnessHash := append([]byte{byte(len(P2WPKH.WitnessProgram()))}, P2WPKH.WitnessProgram()...)
+	witnessProgram := append(witnessVersion, witnessHash...)
+
+	return btcutil.NewAddressScriptHash(witnessProgram, net)
+}
+
+// AddressP2WPKH converts the extended key to a bitcoin pay-to-witness-public-key-hash
+// for the passed network.
+func (k *ExtendedKey) AddressP2WPKH(net *chaincfg.Params) (*btcutil.AddressWitnessPubKeyHash, error) {
+	pkHash := btcutil.Hash160(k.pubKeyBytes())
+	return btcutil.NewAddressWitnessPubKeyHash(pkHash, net)
+}
+
 // paddedAppend appends the src byte slice to dst, returning the new slice.
 // If the length of the source is smaller than the passed size, leading zero
 // bytes are appended to the dst slice before appending src.

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -504,6 +504,16 @@ func (k *ExtendedKey) ECPrivKey() (*btcec.PrivateKey, error) {
 	return privKey, nil
 }
 
+// Address converts the extended key to a standard bitcoin pay-to-pubkey-hash
+// address for the passed network.
+//
+// Deprecated: Address exists for historical compatibility and should not be
+// used. To generate an address use the function for the specific type of
+// address you need.
+func (k *ExtendedKey) Address(net *chaincfg.Params) (*btcutil.AddressPubKeyHash, error) {
+	return k.AddressP2PKH(net)
+}
+
 // AddressP2PKH converts the extended key to a standard bitcoin pay-to-pubkey-hash
 // address for the passed network.
 func (k *ExtendedKey) AddressP2PKH(net *chaincfg.Params) (*btcutil.AddressPubKeyHash, error) {

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -559,38 +559,44 @@ func TestGenerateSeed(t *testing.T) {
 // TestExtendedKeyAPI ensures the API on the ExtendedKey type works as intended.
 func TestExtendedKeyAPI(t *testing.T) {
 	tests := []struct {
-		name         string
-		extKey       string
-		isPrivate    bool
-		parentFP     uint32
-		chainCode    []byte
-		childNum     uint32
-		privKey      string
-		privKeyErr   error
-		pubKey       string
-		addressP2PKH string
+		name           string
+		extKey         string
+		isPrivate      bool
+		parentFP       uint32
+		chainCode      []byte
+		childNum       uint32
+		privKey        string
+		privKeyErr     error
+		pubKey         string
+		addressP2PKH   string
+		addressNP2WPKH string
+		addressP2WPKH  string
 	}{
 		{
-			name:         "test vector 1 master node private",
-			extKey:       "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
-			isPrivate:    true,
-			parentFP:     0,
-			chainCode:    []byte{135, 61, 255, 129, 192, 47, 82, 86, 35, 253, 31, 229, 22, 126, 172, 58, 85, 160, 73, 222, 61, 49, 75, 180, 46, 226, 39, 255, 237, 55, 213, 8},
-			childNum:     0,
-			privKey:      "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35",
-			pubKey:       "0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2",
-			addressP2PKH: "15mKKb2eos1hWa6tisdPwwDC1a5J1y9nma",
+			name:           "test vector 1 master node private",
+			extKey:         "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+			isPrivate:      true,
+			parentFP:       0,
+			chainCode:      []byte{135, 61, 255, 129, 192, 47, 82, 86, 35, 253, 31, 229, 22, 126, 172, 58, 85, 160, 73, 222, 61, 49, 75, 180, 46, 226, 39, 255, 237, 55, 213, 8},
+			childNum:       0,
+			privKey:        "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35",
+			pubKey:         "0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2",
+			addressP2PKH:   "15mKKb2eos1hWa6tisdPwwDC1a5J1y9nma",
+			addressNP2WPKH: "3PpgpssV7mcAGpZRWiCWhodUTnjpoSZg7a",
+			addressP2WPKH:  "bc1qx3ppj0smkuy3d6g525sh9n2w9k7fm7q3x30rtg",
 		},
 		{
-			name:         "test vector 1 chain m/0H/1/2H public",
-			extKey:       "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
-			isPrivate:    false,
-			parentFP:     3203769081,
-			chainCode:    []byte{4, 70, 107, 156, 200, 225, 97, 233, 102, 64, 156, 165, 41, 134, 197, 132, 240, 126, 157, 200, 31, 115, 93, 182, 131, 195, 255, 110, 199, 177, 80, 63},
-			childNum:     2147483650,
-			privKeyErr:   ErrNotPrivExtKey,
-			pubKey:       "0357bfe1e341d01c69fe5654309956cbea516822fba8a601743a012a7896ee8dc2",
-			addressP2PKH: "1NjxqbA9aZWnh17q1UW3rB4EPu79wDXj7x",
+			name:           "test vector 1 chain m/0H/1/2H public",
+			extKey:         "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+			isPrivate:      false,
+			parentFP:       3203769081,
+			chainCode:      []byte{4, 70, 107, 156, 200, 225, 97, 233, 102, 64, 156, 165, 41, 134, 197, 132, 240, 126, 157, 200, 31, 115, 93, 182, 131, 195, 255, 110, 199, 177, 80, 63},
+			childNum:       2147483650,
+			privKeyErr:     ErrNotPrivExtKey,
+			pubKey:         "0357bfe1e341d01c69fe5654309956cbea516822fba8a601743a012a7896ee8dc2",
+			addressP2PKH:   "1NjxqbA9aZWnh17q1UW3rB4EPu79wDXj7x",
+			addressNP2WPKH: "3NpdZ19ArtjGyY4jDd7gzz1vHGi67wG6et",
+			addressP2WPKH:  "bc1qaeatjrx7265vpc4mpp4vf96ghrdemnnj5l9kr5",
 		},
 	}
 
@@ -679,6 +685,32 @@ func TestExtendedKeyAPI(t *testing.T) {
 			t.Errorf("P2PKH Address #%d (%s): mismatched address -- want "+
 				"%s, got %s", i, test.name, test.addressP2PKH,
 				addr.EncodeAddress())
+			continue
+		}
+
+		addrNP2WPKH, err := key.AddressNP2WPKH(&chaincfg.MainNetParams)
+		if err != nil {
+			t.Errorf("NP2WPKH address #%d (%s): unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+		if addrNP2WPKH.EncodeAddress() != test.addressNP2WPKH {
+			t.Errorf("NP2WPKH address #%d (%s): mismatched address -- want "+
+				"%s, got %s", i, test.name, test.addressNP2WPKH,
+				addrNP2WPKH.EncodeAddress())
+			continue
+		}
+
+		addrP2WPKH, err := key.AddressP2WPKH(&chaincfg.MainNetParams)
+		if err != nil {
+			t.Errorf("NP2WPKH address #%d (%s): unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+		if addrP2WPKH.EncodeAddress() != test.addressP2WPKH {
+			t.Errorf("NP2WPKH address #%d (%s): mismatched address -- want "+
+				"%s, got %s", i, test.name, test.addressP2WPKH,
+				addrP2WPKH.EncodeAddress())
 			continue
 		}
 	}

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -703,12 +703,12 @@ func TestExtendedKeyAPI(t *testing.T) {
 
 		addrP2WPKH, err := key.AddressP2WPKH(&chaincfg.MainNetParams)
 		if err != nil {
-			t.Errorf("NP2WPKH address #%d (%s): unexpected error: %v", i,
+			t.Errorf("P2WPKH address #%d (%s): unexpected error: %v", i,
 				test.name, err)
 			continue
 		}
 		if addrP2WPKH.EncodeAddress() != test.addressP2WPKH {
-			t.Errorf("NP2WPKH address #%d (%s): mismatched address -- want "+
+			t.Errorf("P2WPKH address #%d (%s): mismatched address -- want "+
 				"%s, got %s", i, test.name, test.addressP2WPKH,
 				addrP2WPKH.EncodeAddress())
 			continue

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -559,38 +559,38 @@ func TestGenerateSeed(t *testing.T) {
 // TestExtendedKeyAPI ensures the API on the ExtendedKey type works as intended.
 func TestExtendedKeyAPI(t *testing.T) {
 	tests := []struct {
-		name       string
-		extKey     string
-		isPrivate  bool
-		parentFP   uint32
-		chainCode  []byte
-		childNum   uint32
-		privKey    string
-		privKeyErr error
-		pubKey     string
-		address    string
+		name         string
+		extKey       string
+		isPrivate    bool
+		parentFP     uint32
+		chainCode    []byte
+		childNum     uint32
+		privKey      string
+		privKeyErr   error
+		pubKey       string
+		addressP2PKH string
 	}{
 		{
-			name:      "test vector 1 master node private",
-			extKey:    "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
-			isPrivate: true,
-			parentFP:  0,
-			chainCode: []byte{135, 61, 255, 129, 192, 47, 82, 86, 35, 253, 31, 229, 22, 126, 172, 58, 85, 160, 73, 222, 61, 49, 75, 180, 46, 226, 39, 255, 237, 55, 213, 8},
-			childNum:  0,
-			privKey:   "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35",
-			pubKey:    "0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2",
-			address:   "15mKKb2eos1hWa6tisdPwwDC1a5J1y9nma",
+			name:         "test vector 1 master node private",
+			extKey:       "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+			isPrivate:    true,
+			parentFP:     0,
+			chainCode:    []byte{135, 61, 255, 129, 192, 47, 82, 86, 35, 253, 31, 229, 22, 126, 172, 58, 85, 160, 73, 222, 61, 49, 75, 180, 46, 226, 39, 255, 237, 55, 213, 8},
+			childNum:     0,
+			privKey:      "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35",
+			pubKey:       "0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2",
+			addressP2PKH: "15mKKb2eos1hWa6tisdPwwDC1a5J1y9nma",
 		},
 		{
-			name:       "test vector 1 chain m/0H/1/2H public",
-			extKey:     "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
-			isPrivate:  false,
-			parentFP:   3203769081,
-			chainCode:  []byte{4, 70, 107, 156, 200, 225, 97, 233, 102, 64, 156, 165, 41, 134, 197, 132, 240, 126, 157, 200, 31, 115, 93, 182, 131, 195, 255, 110, 199, 177, 80, 63},
-			childNum:   2147483650,
-			privKeyErr: ErrNotPrivExtKey,
-			pubKey:     "0357bfe1e341d01c69fe5654309956cbea516822fba8a601743a012a7896ee8dc2",
-			address:    "1NjxqbA9aZWnh17q1UW3rB4EPu79wDXj7x",
+			name:         "test vector 1 chain m/0H/1/2H public",
+			extKey:       "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+			isPrivate:    false,
+			parentFP:     3203769081,
+			chainCode:    []byte{4, 70, 107, 156, 200, 225, 97, 233, 102, 64, 156, 165, 41, 134, 197, 132, 240, 126, 157, 200, 31, 115, 93, 182, 131, 195, 255, 110, 199, 177, 80, 63},
+			childNum:     2147483650,
+			privKeyErr:   ErrNotPrivExtKey,
+			pubKey:       "0357bfe1e341d01c69fe5654309956cbea516822fba8a601743a012a7896ee8dc2",
+			addressP2PKH: "1NjxqbA9aZWnh17q1UW3rB4EPu79wDXj7x",
 		},
 	}
 
@@ -669,15 +669,15 @@ func TestExtendedKeyAPI(t *testing.T) {
 			continue
 		}
 
-		addr, err := key.Address(&chaincfg.MainNetParams)
+		addr, err := key.AddressP2PKH(&chaincfg.MainNetParams)
 		if err != nil {
-			t.Errorf("Address #%d (%s): unexpected error: %v", i,
+			t.Errorf("P2PKH Address #%d (%s): unexpected error: %v", i,
 				test.name, err)
 			continue
 		}
-		if addr.EncodeAddress() != test.address {
-			t.Errorf("Address #%d (%s): mismatched address -- want "+
-				"%s, got %s", i, test.name, test.address,
+		if addr.EncodeAddress() != test.addressP2PKH {
+			t.Errorf("P2PKH Address #%d (%s): mismatched address -- want "+
+				"%s, got %s", i, test.name, test.addressP2PKH,
 				addr.EncodeAddress())
 			continue
 		}
@@ -981,14 +981,14 @@ func TestZero(t *testing.T) {
 		}
 
 		wantAddr := "1HT7xU2Ngenf7D4yocz2SAcnNLW7rK8d4E"
-		addr, err := key.Address(&chaincfg.MainNetParams)
+		addr, err := key.AddressP2PKH(&chaincfg.MainNetParams)
 		if err != nil {
-			t.Errorf("Addres s #%d (%s): unexpected error: %v", i,
+			t.Errorf("P2PKH Address #%d (%s): unexpected error: %v", i,
 				testName, err)
 			return false
 		}
 		if addr.EncodeAddress() != wantAddr {
-			t.Errorf("Address #%d (%s): mismatched address -- want "+
+			t.Errorf("P2PKH Address #%d (%s): mismatched address -- want "+
 				"%s, got %s", i, testName, wantAddr,
 				addr.EncodeAddress())
 			return false


### PR DESCRIPTION
Resolves #105 

Credit to @bjarnemagnussen for writing the original code. I manually rebased his patch on top of latest master, fixed a typo and renamed the current ExtendedKey.Address function to be in line with the naming scheme from the patch. In place of the renamed function a simple wrapper function with a deprecation notice was added for backwards compatibility.