### PR TITLE
bech32: add new EncodeM and DecodeGeneric functions for bech32

### DIFF
--- a/bech32/bech32_test.go
+++ b/bech32/bech32_test.go
@@ -22,17 +22,18 @@ func TestBech32(t *testing.T) {
 		expectedError error
 	}{
 		{"A12UEL5L", nil},
+		{"a12uel5l", nil},
 		{"an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs", nil},
 		{"abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw", nil},
 		{"11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", nil},
 		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", nil},
-		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e2w", ErrInvalidChecksum{"2y9e3w", "2y9e2w"}},              // invalid checksum
-		{"s lit1checkupstagehandshakeupstreamerranterredcaperredp8hs2p", ErrInvalidCharacter(' ')},                            // invalid character (space) in hrp
-		{"spl\x7Ft1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", ErrInvalidCharacter(127)},                         // invalid character (DEL) in hrp
-		{"split1cheo2y9e2w", ErrNonCharsetChar('o')},                                                                          // invalid character (o) in data part
-		{"split1a2y9w", ErrInvalidSeparatorIndex(5)},                                                                          // too short data part
-		{"1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", ErrInvalidSeparatorIndex(0)},                              // empty hrp
-		{"11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", ErrInvalidLength(91)}, // too long
+		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e2w", ErrInvalidChecksum{"2y9e3w", "2y9e3wlc445v", "2y9e2w"}}, // invalid checksum
+		{"s lit1checkupstagehandshakeupstreamerranterredcaperredp8hs2p", ErrInvalidCharacter(' ')},                               // invalid character (space) in hrp
+		{"spl\x7Ft1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", ErrInvalidCharacter(127)},                            // invalid character (DEL) in hrp
+		{"split1cheo2y9e2w", ErrNonCharsetChar('o')},                                                                             // invalid character (o) in data part
+		{"split1a2y9w", ErrInvalidSeparatorIndex(5)},                                                                             // too short data part
+		{"1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", ErrInvalidSeparatorIndex(0)},                                 // empty hrp
+		{"11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", ErrInvalidLength(91)},    // too long
 
 		// Additional test vectors used in bitcoin core
 		{" 1nwldj5", ErrInvalidCharacter(' ')},
@@ -44,7 +45,7 @@ func TestBech32(t *testing.T) {
 		{"x1b4n0q5v", ErrNonCharsetChar(98)},
 		{"li1dgmt3", ErrInvalidSeparatorIndex(2)},
 		{"de1lg7wt\xff", ErrInvalidCharacter(0xff)},
-		{"A1G7SGD8", ErrInvalidChecksum{"2uel5l", "g7sgd8"}},
+		{"A1G7SGD8", ErrInvalidChecksum{"2uel5l", "2uel5llqfn3a", "g7sgd8"}},
 		{"10a06t8", ErrInvalidLength(7)},
 		{"1qzzfhee", ErrInvalidSeparatorIndex(0)},
 		{"a12UEL5L", ErrMixedCase{}},
@@ -82,6 +83,127 @@ func TestBech32(t *testing.T) {
 		_, _, err = Decode(flipped)
 		if err == nil {
 			t.Error("expected decoding to fail")
+		}
+	}
+}
+
+// TestBech32M tests that the following set of strings, based on the test
+// vectors in BIP-350 are either valid or invalid using the new bech32m
+// checksum algo. Some of these strings are similar to the set of above test
+// vectors, but end up with different checksums.
+func TestBech32M(t *testing.T) {
+	tests := []struct {
+		str           string
+		expectedError error
+	}{
+		{"A1LQFN3A", nil},
+		{"a1lqfn3a", nil},
+		{"an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6", nil},
+		{"abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx", nil},
+		{"11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8", nil},
+		{"split1checkupstagehandshakeupstreamerranterredcaperredlc445v", nil},
+		{"?1v759aa", nil},
+
+		// Additional test vectors used in bitcoin core
+		{"\x201xj0phk", ErrInvalidCharacter('\x20')},
+		{"\x7f1g6xzxy", ErrInvalidCharacter('\x7f')},
+		{"\x801vctc34", ErrInvalidCharacter('\x80')},
+		{"an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4", ErrInvalidLength(91)},
+		{"qyrz8wqd2c9m", ErrInvalidSeparatorIndex(-1)},
+		{"1qyrz8wqd2c9m", ErrInvalidSeparatorIndex(0)},
+		{"y1b0jsk6g", ErrNonCharsetChar(98)},
+		{"lt1igcx5c0", ErrNonCharsetChar(105)},
+		{"in1muywd", ErrInvalidSeparatorIndex(2)},
+		{"mm1crxm3i", ErrNonCharsetChar(105)},
+		{"au1s5cgom", ErrNonCharsetChar(111)},
+		{"M1VUXWEZ", ErrInvalidChecksum{"mzl49c", "mzl49cw70eq6", "vuxwez"}},
+		{"16plkw9", ErrInvalidLength(7)},
+		{"1p2gdwpf", ErrInvalidSeparatorIndex(0)},
+
+		{" 1nwldj5", ErrInvalidCharacter(' ')},
+		{"\x7f" + "1axkwrx", ErrInvalidCharacter(0x7f)},
+		{"\x801eym55h", ErrInvalidCharacter(0x80)},
+	}
+
+	for i, test := range tests {
+		str := test.str
+		hrp, decoded, err := Decode(str)
+		if test.expectedError != err {
+			t.Errorf("%d: (%v) expected decoding error %v "+
+				"instead got %v", i, str, test.expectedError,
+				err)
+			continue
+		}
+
+		if err != nil {
+			// End test case here if a decoding error was expected.
+			continue
+		}
+
+		// Check that it encodes to the same string, using bech32 m.
+		encoded, err := EncodeM(hrp, decoded)
+		if err != nil {
+			t.Errorf("encoding failed: %v", err)
+		}
+
+		if encoded != strings.ToLower(str) {
+			t.Errorf("expected data to encode to %v, but got %v",
+				str, encoded)
+		}
+
+		// Flip a bit in the string an make sure it is caught.
+		pos := strings.LastIndexAny(str, "1")
+		flipped := str[:pos+1] + string((str[pos+1] ^ 1)) + str[pos+2:]
+		_, _, err = Decode(flipped)
+		if err == nil {
+			t.Error("expected decoding to fail")
+		}
+	}
+}
+
+// TestBech32DecodeGeneric tests that given a bech32 string, or a bech32m
+// string, the proper checksum version is returned so that callers can perform
+// segwit addr validation.
+func TestBech32DecodeGeneric(t *testing.T) {
+	tests := []struct {
+		str     string
+		version Version
+	}{
+		{"A1LQFN3A", VersionM},
+		{"a1lqfn3a", VersionM},
+		{"an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6", VersionM},
+		{"abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx", VersionM},
+		{"11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8", VersionM},
+		{"split1checkupstagehandshakeupstreamerranterredcaperredlc445v", VersionM},
+		{"?1v759aa", VersionM},
+
+		{"A12UEL5L", Version0},
+		{"a12uel5l", Version0},
+		{"an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs", Version0},
+		{"abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw", Version0},
+		{"11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", Version0},
+		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", Version0},
+
+		{"BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", Version0},
+		{"tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", Version0},
+		{"bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y", VersionM},
+		{"BC1SW50QGDZ25J", VersionM},
+		{"bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", VersionM},
+		{"tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", Version0},
+		{"tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c", VersionM},
+		{"bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", VersionM},
+	}
+	for i, test := range tests {
+		_, _, version, err := DecodeGeneric(test.str)
+		if err != nil {
+			t.Errorf("%d: (%v) unexpected error during "+
+				"decoding: %v", i, test.str, err)
+			continue
+		}
+
+		if version != test.version {
+			t.Errorf("(%v): invalid version: expected %v, got %v",
+				test.str, test.version, version)
 		}
 	}
 }
@@ -242,7 +364,7 @@ func TestBech32Base256(t *testing.T) {
 	}, {
 		name:    "same as previous but with checksum invalidated",
 		encoded: "split1checkupstagehandshakeupstreamerranterredcaperred2y9e2w",
-		err:     ErrInvalidChecksum{"2y9e3w", "2y9e2w"},
+		err:     ErrInvalidChecksum{"2y9e3w", "2y9e3wlc445v", "2y9e2w"},
 	}, {
 		name:    "hrp with invalid character (space)",
 		encoded: "s lit1checkupstagehandshakeupstreamerranterredcaperredp8hs2p",

--- a/bech32/error.go
+++ b/bech32/error.go
@@ -65,15 +65,17 @@ func (e ErrNonCharsetChar) Error() string {
 }
 
 // ErrInvalidChecksum is returned when the extracted checksum of the string
-// is different than what was expected.
+// is different than what was expected. Both the original version, as well as
+// the new bech32m checksum may be specified.
 type ErrInvalidChecksum struct {
-	Expected string
-	Actual   string
+	Expected  string
+	ExpectedM string
+	Actual    string
 }
 
 func (e ErrInvalidChecksum) Error() string {
-	return fmt.Sprintf("invalid checksum (expected %v got %v)",
-		e.Expected, e.Actual)
+	return fmt.Sprintf("invalid checksum (expected (bech32=%v, "+
+		"bech32m=%v), got %v)", e.Expected, e.ExpectedM, e.Actual)
 }
 
 // ErrInvalidDataByte is returned when a byte outside the range required for

--- a/bech32/version.go
+++ b/bech32/version.go
@@ -1,0 +1,43 @@
+package bech32
+
+// ChecksumConst is a type that represents the currently defined bech32
+// checksum constants.
+type ChecksumConst int
+
+const (
+	// Version0Const is the original constant used in the checksum
+	// verification for bech32.
+	Version0Const ChecksumConst = 1
+
+	// VersionMConst is the new constant used for bech32m checksum
+	// verification.
+	VersionMConst ChecksumConst = 0x2bc830a3
+)
+
+// Version defines the current set of bech32 versions.
+type Version uint8
+
+const (
+	// Version0 defines the original bech version.
+	Version0 Version = iota
+
+	// VersionM is the new bech32 version defined in BIP-350, also known as
+	// bech32m.
+	VersionM
+
+	// VersionUnknown denotes an unknown bech version.
+	VersionUnknown
+)
+
+// VersionToConsts maps bech32 versions to the checksum constant to be used
+// when encoding, and asserting a particular version when decoding.
+var VersionToConsts = map[Version]ChecksumConst{
+	Version0: Version0Const,
+	VersionM: VersionMConst,
+}
+
+// ConstsToVersion maps a bech32 constant to the version it's associated with.
+var ConstsToVersion = map[ChecksumConst]Version{
+	Version0Const: Version0,
+	VersionMConst: VersionM,
+}


### PR DESCRIPTION
In this commit, we add two new package level functions: `EncodeM`, and
`DecodeGeneric`. The new encode method is intended to allow callers to
specify that they want to use the new bech32m checksum. This should be
used when encoding segwit addresses with version 1 and beyond. The new
`DecodeGeneric` function allows a caller to decode a bech32 and bech32m
string with a single function. A new return value is added which is the
version of the returned bech32 string, which allows callers to perform
additional segwit addr validation (v1+ should use bech32m etc).

We opted to add new functions rather than modifying the existing
functions to not cause a breaking API change, as most uses in the wild
can just use the existing functions, and only taproot related logic/code
needs to worry about the new methods.

A series of tests have been added to ensure that `DecodeGeneric`
extracts the proper bech version, and we've also adopted the bech32m
tests from BIP 350.

Fixes part of https://github.com/btcsuite/btcd/issues/1735. 

Fixes https://github.com/btcsuite/btcutil/issues/195